### PR TITLE
Add first library implementation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,105 @@
+---
+Language:        Cpp
+# BasedOnStyle:  WebKit
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:   100
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 10
+PenaltyBreakBeforeFirstCallParameter: 1000
+PenaltyBreakComment: 10
+PenaltyBreakString: 10
+PenaltyExcessCharacter: 100
+PenaltyReturnTypeOnItsOwnLine: 5
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+-*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+#build
+/build/
+*.user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,70 @@
+# Authors: Giulio Romualdi
+# CopyPolicy: Released under the terms of the LGPLv2.1 or later
+
+# Set cmake mimimun version
+cmake_minimum_required(VERSION 3.5)
+
+project(LieGroupControllers
+  VERSION 0.0.1)
+
+# ouptut paths
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+
+# Build shared libs
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+if(MSVC)
+  set(CMAKE_DEBUG_POSTFIX "d")
+endif()
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
+
+# Disable C and C++ compiler extensions.
+# C/CXX_EXTENSIONS are ON by default to allow the compilers to use extended
+# variants of the C/CXX language.
+# However, this could expose cross-platform bugs in user code or in the headers
+# of third-party dependencies and thus it is strongly suggested to turn
+# extensions off.
+set(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# add GNU dirs
+include(GNUInstallDirs)
+
+include(CMakePackageConfigHelpers)
+
+option(ENABLE_RPATH "Enable RPATH for this library" ON)
+mark_as_advanced(ENABLE_RPATH)
+include(AddInstallRPATHSupport)
+add_install_rpath_support(BIN_DIRS "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}"
+  LIB_DIRS "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
+  DEPENDS ENABLE_RPATH
+  USE_LINK_PATH)
+
+# Encourage user to specify a build type (e.g. Release, Debug, etc.), otherwise set it to Release.
+if(NOT CMAKE_CONFIGURATION_TYPES)
+  if(NOT CMAKE_BUILD_TYPE)
+      message(STATUS "Setting build type to 'Release' as none was specified.")
+      set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
+  endif()
+endif()
+
+option(BUILD_TESTING "Create tests using CMake" OFF)
+include(CTest)
+
+# Check LieGroupControllers dependencies, find necessary libraries.
+include(LieGroupControllersDependencies)
+
+# Set default build type to "Release" in single-config generators
+if(NOT CMAKE_CONFIGURATION_TYPES)
+    if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING
+        "Choose the type of build, recommanded options are: Debug or Release" FORCE)
+    endif()
+    set(LIEGROUPCONTROLLERS_BUILD_TYPES "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS ${LIEGROUPCONTROLLERS_BUILD_TYPES})
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,8 +81,8 @@ set(${LIBRARY_TARGET_NAME}_PRIVATE_HDR
   )
 
 set(${LIBRARY_TARGET_NAME}_PRIVATE_PROPORTIONAL_HDR
-  include/LieGroupControllers/impl/ProportionalController/ProportionalController.h
-  include/LieGroupControllers/impl/ProportionalController/ProportionalController_base.h
+  include/LieGroupControllers/impl/ProportionalController/Controller.h
+  include/LieGroupControllers/impl/ProportionalController/ControllerBase.h
   )
 
 add_library(${LIBRARY_TARGET_NAME} INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,11 +71,18 @@ endif()
 
 set(LIBRARY_TARGET_NAME LieGroupControllers)
 
-
 set(${LIBRARY_TARGET_NAME}_PUBLIC_HDR
+  include/LieGroupControllers/ProportionalController.h
   )
 
 set(${LIBRARY_TARGET_NAME}_PRIVATE_HDR
+  include/LieGroupControllers/impl/traits.h
+  include/LieGroupControllers/impl/ControllerBase.h
+  )
+
+set(${LIBRARY_TARGET_NAME}_PRIVATE_PROPORTIONAL_HDR
+  include/LieGroupControllers/impl/ProportionalController/ProportionalController.h
+  include/LieGroupControllers/impl/ProportionalController/ProportionalController_base.h
   )
 
 add_library(${LIBRARY_TARGET_NAME} INTERFACE)
@@ -85,24 +92,32 @@ target_include_directories(${LIBRARY_TARGET_NAME} INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
-target_link_libraries(${LIBRARY_TARGET_NAME} INTERFACE manif::manif Eigen3::Eigen)
+target_link_libraries(${LIBRARY_TARGET_NAME} INTERFACE Eigen3::Eigen MANIF::manif)
 
 install(TARGETS ${LIBRARY_TARGET_NAME} EXPORT  ${PROJECT_NAME})
 
 install(FILES ${${LIBRARY_TARGET_NAME}_PUBLIC_HDR}
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRARY_TARGET_NAME}")
+
 install(FILES ${${LIBRARY_TARGET_NAME}_PRIVATE_HDR}
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRARY_TARGET_NAME}/impl")
+
+install(FILES ${${LIBRARY_TARGET_NAME}_PRIVATE_PROPORTIONAL_HDR}
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRARY_TARGET_NAME}/impl/ProportionalController")
 
 include(InstallBasicPackageFiles)
 set(LIEGROUPCONTROLLERS_PUBLIC_DEPENDENCIES manif "Eigen3 3.2.92")
 
 install_basic_package_files(${PROJECT_NAME}
-                            NAMESPACE LieGroupControllers::
-                            VERSION ${LieGroupControllers_VERSION}
-                            COMPATIBILITY AnyNewerVersion
-                            VARS_PREFIX ${PROJECT_NAME}
-                            NO_CHECK_REQUIRED_COMPONENTS_MACRO
-                            DEPENDENCIES ${LIEGROUPCONTROLLERS_PUBLIC_DEPENDENCIES})
+  NAMESPACE LieGroupControllers::
+  VERSION ${LieGroupControllers_VERSION}
+  COMPATIBILITY AnyNewerVersion
+  VARS_PREFIX ${PROJECT_NAME}
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+  DEPENDENCIES ${LIEGROUPCONTROLLERS_PUBLIC_DEPENDENCIES})
+
+## Testing
+include(AddLieGroupControllersUnitTest)
+add_subdirectory(tests)
 
 include(AddUninstallTarget)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,11 @@ set(${LIBRARY_TARGET_NAME}_PRIVATE_PROPORTIONAL_HDR
   include/LieGroupControllers/impl/ProportionalController/ControllerBase.h
   )
 
+set(${LIBRARY_TARGET_NAME}_PRIVATE_PROPORTIONAL_DERIVATIVE_HDR
+  include/LieGroupControllers/impl/ProportionalDerivativeController/Controller.h
+  include/LieGroupControllers/impl/ProportionalDerivativeController/ControllerBase.h
+  )
+
 add_library(${LIBRARY_TARGET_NAME} INTERFACE)
 add_library(${PROJECT_NAME}::${LIBRARY_TARGET_NAME} ALIAS ${LIBRARY_TARGET_NAME})
 
@@ -104,6 +109,9 @@ install(FILES ${${LIBRARY_TARGET_NAME}_PRIVATE_HDR}
 
 install(FILES ${${LIBRARY_TARGET_NAME}_PRIVATE_PROPORTIONAL_HDR}
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRARY_TARGET_NAME}/impl/ProportionalController")
+
+install(FILES ${${LIBRARY_TARGET_NAME}_PRIVATE_PROPORTIONAL_DERIVATIVE_HDR}
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRARY_TARGET_NAME}/impl/ProportionalDerivativeController")
 
 include(InstallBasicPackageFiles)
 set(LIEGROUPCONTROLLERS_PUBLIC_DEPENDENCIES manif "Eigen3 3.2.92")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,3 +68,41 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
     set(LIEGROUPCONTROLLERS_BUILD_TYPES "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS ${LIEGROUPCONTROLLERS_BUILD_TYPES})
 endif()
+
+set(LIBRARY_TARGET_NAME LieGroupControllers)
+
+
+set(${LIBRARY_TARGET_NAME}_PUBLIC_HDR
+  )
+
+set(${LIBRARY_TARGET_NAME}_PRIVATE_HDR
+  )
+
+add_library(${LIBRARY_TARGET_NAME} INTERFACE)
+add_library(${PROJECT_NAME}::${LIBRARY_TARGET_NAME} ALIAS ${LIBRARY_TARGET_NAME})
+
+target_include_directories(${LIBRARY_TARGET_NAME} INTERFACE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+
+target_link_libraries(${LIBRARY_TARGET_NAME} INTERFACE manif::manif Eigen3::Eigen)
+
+install(TARGETS ${LIBRARY_TARGET_NAME} EXPORT  ${PROJECT_NAME})
+
+install(FILES ${${LIBRARY_TARGET_NAME}_PUBLIC_HDR}
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRARY_TARGET_NAME}")
+install(FILES ${${LIBRARY_TARGET_NAME}_PRIVATE_HDR}
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRARY_TARGET_NAME}/impl")
+
+include(InstallBasicPackageFiles)
+set(LIEGROUPCONTROLLERS_PUBLIC_DEPENDENCIES manif "Eigen3 3.2.92")
+
+install_basic_package_files(${PROJECT_NAME}
+                            NAMESPACE LieGroupControllers::
+                            VERSION ${LieGroupControllers_VERSION}
+                            COMPATIBILITY AnyNewerVersion
+                            VARS_PREFIX ${PROJECT_NAME}
+                            NO_CHECK_REQUIRED_COMPONENTS_MACRO
+                            DEPENDENCIES ${LIEGROUPCONTROLLERS_PUBLIC_DEPENDENCIES})
+
+include(AddUninstallTarget)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,504 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+    USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random
+  Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# lie-group-controllers
+<p align="center">
+<h1 align="center">lie-group-controllers </h1>
+</p>
+
+<p align="center">
+<a href="https://isocpp.org"><img src="https://img.shields.io/badge/standard-C++17-blue.svg?style=flat&logo=c%2B%2B" alt="C++ Standard"/></a>
+<a href="./LICENSE"><img src="https://img.shields.io/badge/license-LGPL-19c2d8.svg" alt="Size" /></a>
+</p>
+
+Header-only C++ libraries containing controllers designed for Lie Groups.
+
+## Dependeces
+- [manif](https://github.com/artivis/manif);
+- [Eigen3](http://eigen.tuxfamily.org/index.php?title=Main_Page);
+- [cmake](https://cmake.org/);
+- [Catch2](https://github.com/catchorg/Catch2) (only for testing).
+
+## Build the library
+### Linux / macOs
+```sh
+git clone https://github.com/GiulioRomualdi/lie-group-controllers.git
+cd lie-group-controllers
+mkdir build && cd build
+cmake ../
+make
+[sudo] make install
+```
+If you want to enable tests set the `BUILD_TESTING` option to `ON`.
+
+## Use lie-groups-controllers in your project
+**lie-groups-controllers** provides native CMake support which allows the library to be easily used in CMake projects. Please add in your `CMakeLists.txt`
+```cmake
+project(foo)
+find_package(LieGroupsControllers REQUIRED)
+add_executable(${PROJECT_NAME} src/foo.cpp)
+target_link_libraries(${PROJECT_NAME} LieGroupsControllers::LieGroupsControllers)
+```
+
+## Bug reports and support
+All types of [issues](https://github.com/GiulioRomualdi/lie-group-controllers/issues/new) are welcome.

--- a/README.md
+++ b/README.md
@@ -10,24 +10,26 @@
 Header-only C++ libraries containing controllers designed for Lie Groups.
 
 ## Dependeces
+
 - [manif](https://github.com/artivis/manif);
 - [Eigen3](http://eigen.tuxfamily.org/index.php?title=Main_Page);
 - [cmake](https://cmake.org/);
 - [Catch2](https://github.com/catchorg/Catch2) (only for testing).
 
 ## Build the library
-### Linux / macOs
+
 ```sh
 git clone https://github.com/GiulioRomualdi/lie-group-controllers.git
 cd lie-group-controllers
 mkdir build && cd build
 cmake ../
-make
+cmake --build .
 [sudo] make install
 ```
 If you want to enable tests set the `BUILD_TESTING` option to `ON`.
 
 ## Use lie-groups-controllers in your project
+
 **lie-groups-controllers** provides native CMake support which allows the library to be easily used in CMake projects. Please add in your `CMakeLists.txt`
 ```cmake
 project(foo)
@@ -37,4 +39,5 @@ target_link_libraries(${PROJECT_NAME} LieGroupsControllers::LieGroupsControllers
 ```
 
 ## Bug reports and support
+
 All types of [issues](https://github.com/GiulioRomualdi/lie-group-controllers/issues/new) are welcome.

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Header-only C++ libraries containing controllers designed for Lie Groups.
 
 ## Dependeces
 
-- [manif](https://github.com/artivis/manif);
-- [Eigen3](http://eigen.tuxfamily.org/index.php?title=Main_Page);
-- [cmake](https://cmake.org/);
-- [Catch2](https://github.com/catchorg/Catch2) (only for testing).
+- [manif](https://github.com/artivis/manif)
+- [Eigen3](http://eigen.tuxfamily.org/index.php?title=Main_Page)
+- [cmake](https://cmake.org/)
+- [Catch2](https://github.com/catchorg/Catch2) (only for testing)
 
 ## Build the library
 
@@ -40,4 +40,4 @@ target_link_libraries(${PROJECT_NAME} LieGroupsControllers::LieGroupsControllers
 
 ## Bug reports and support
 
-All types of [issues](https://github.com/GiulioRomualdi/lie-group-controllers/issues/new) are welcome.
+All types of [issues](https://github.com/dic-iit/lie-group-controllers/issues/new) are welcome.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Header-only C++ libraries containing controllers designed for Lie Groups.
 
 ## Some theory behind the library
 
-The aim of the library is to contain same controllers designed in lie groups. The library depends only on `Eigen` and [`manif`](https://github.com/artivis/manif).
+The aim of the library is to contain some controllers designed in lie groups. The library depends only on `Eigen` and [`manif`](https://github.com/artivis/manif).
 
 All the controllers defined in `lie-group-controllers` have in common that they inherit from a templated base class ([CRTP](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern)). It allows one to write generic code abstracting the controller details. This follows the structure of `manif` and `Eigen`.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,36 @@
 
 Header-only C++ libraries containing controllers designed for Lie Groups.
 
+## Some theory behind the library
+
+The aim of the library is to contain same controllers designed in lie groups. The library depends only on `Eigen` and [`manif`](https://github.com/artivis/manif).
+
+All the controllers defined in `lie-group-controllers` have in common that they inherit from a templated base class ([CRTP](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern)). It allows one to write generic code abstracting the controller details. This follows the structure of `manif` and `Eigen`.
+
+The library implements two controllers:
+1. Proportional Controller (`P controller`)
+2. Proportional Derivative Controller (`PD controller`)
+
+The controllers have the following form
+
+|       Proportional Controller      | Proportional Derivative Controller |
+|:-----------------------:|:-------------:|
+| ![img-f6214bd2482f678b](https://user-images.githubusercontent.com/16744101/89174620-77c5b100-d586-11ea-88f7-318343c13b0f.png)  | ![img-40c85670ed9bec65](https://user-images.githubusercontent.com/16744101/89174628-7b593800-d586-11ea-8219-d3ea2cb70901.png)        |
+
+where `X` and `Xᵈ` are elements of a Lie group. `∘` is the group operator. `ψ` represents an element in the Lie algebra of the Lie group whose coordinates are expressed in `ℝⁿ`.
+
+At the moment, the controllers support all the group defined in `manif`. Namely:
+- ℝ(n): Euclidean space with addition.
+- SO(2): rotations in the plane.
+- SE(2): rigid motion (rotation and translation) in the plane.
+- SO(3): rotations in 3D space.
+- SE(3): rigid motion (rotation and translation) in 3D space.
+
+Please you can find further information in
+```
+Modern Robotics: Mechanics, Planning, and Control," Kevin M. Lynch and Frank C. Park, Cambridge University Press, 2017, ISBN 9781107156302
+```
+
 ## Dependeces
 
 - [manif](https://github.com/artivis/manif)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ If you want to enable tests set the `BUILD_TESTING` option to `ON`.
 ## Use lie-groups-controllers in your project
 
 **lie-groups-controllers** provides native CMake support which allows the library to be easily used in CMake projects. Please add in your `CMakeLists.txt`
+
 ```cmake
 project(foo)
 find_package(LieGroupsControllers REQUIRED)
@@ -41,3 +42,7 @@ target_link_libraries(${PROJECT_NAME} LieGroupsControllers::LieGroupsControllers
 ## Bug reports and support
 
 All types of [issues](https://github.com/dic-iit/lie-group-controllers/issues/new) are welcome.
+
+## Note
+
+The original version of the library can be found [here](https://github.com/GiulioRomualdi/lie-group-controllers).

--- a/cmake/AddInstallRPATHSupport.cmake
+++ b/cmake/AddInstallRPATHSupport.cmake
@@ -1,0 +1,167 @@
+#.rst:
+# AddInstallRPATHSupport
+# ----------------------
+#
+# Add support to RPATH during installation to your project::
+#
+#   add_install_rpath_support([BIN_DIRS dir [dir]]
+#                             [LIB_DIRS dir [dir]]
+#                             [INSTALL_NAME_DIR [dir]]
+#                             [DEPENDS condition [condition]]
+#                             [USE_LINK_PATH])
+#
+# Normally (depending on the platform) when you install a shared
+# library you can either specify its absolute path as the install name,
+# or leave just the library name itself. In the former case the library
+# will be correctly linked during run time by all executables and other
+# shared libraries, but it must not change its install location. This
+# is often the case for libraries installed in the system default
+# library directory (e.g. ``/usr/lib``).
+# In the latter case, instead, the library can be moved anywhere in the
+# file system but at run time the dynamic linker must be able to find
+# it. This is often accomplished by setting environmental variables
+# (i.e. ``LD_LIBRARY_PATH`` on Linux).
+# This procedure is usually not desirable for two main reasons:
+#
+# - by setting the variable you are changing the default behaviour
+#   of the dynamic linker thus potentially breaking executables (not as
+#   destructive as ``LD_PRELOAD``)
+# - the variable will be used only by applications spawned by the shell
+#   and not by other processes.
+#
+# RPATH is aimed to solve the issues introduced by the second
+# installation method. Using run-path dependent libraries you can
+# create a directory structure containing executables and dependent
+# libraries that users can relocate without breaking it.
+# A run-path dependent library is a dependent library whose complete
+# install name is not known when the library is created.
+# Instead, the library specifies that the dynamic loader must resolve
+# the library’s install name when it loads the executable that depends
+# on the library. The executable or the other shared library will
+# hardcode in the binary itself the additional search directories
+# to be passed to the dynamic linker. This works great in conjunction
+# with relative paths.
+# This command will enable support to RPATH to your project.
+# It will enable the following things:
+#
+#  - If the project builds shared libraries it will generate a run-path
+#    enabled shared library, i.e. its install name will be resolved
+#    only at run time.
+#  - In all cases (building executables and/or shared libraries)
+#    dependent shared libraries with RPATH support will be properly
+#
+# The command has the following parameters:
+#
+# Options:
+#  - ``USE_LINK_PATH``: if passed the command will automatically adds to
+#    the RPATH the path to all the dependent libraries.
+#
+# Arguments:
+#  - ``BIN_DIRS`` list of directories when the targets (executable and
+#    plugins) will be installed.
+#  - ``LIB_DIRS`` list of directories to be added to the RPATH. These
+#    directories will be added "relative" w.r.t. the ``BIN_DIRS`` and
+#    ``LIB_DIRS``.
+#  - ``INSTALL_NAME_DIR`` directory where the libraries will be installed.
+#    This variable will be used only if ``CMAKE_SKIP_RPATH`` or
+#    ``CMAKE_SKIP_INSTALL_RPATH`` is set to ``TRUE`` as it will set the
+#    ``INSTALL_NAME_DIR`` on all targets
+#  - ``DEPENDS`` list of conditions that should be ``TRUE`` to enable
+#    RPATH, for example ``FOO; NOT BAR``.
+#
+# Note: see https://gitlab.kitware.com/cmake/cmake/issues/16589 for further
+# details.
+
+#=======================================================================
+# Copyright 2014 Istituto Italiano di Tecnologia (IIT)
+# @author Francesco Romano <francesco.romano@iit.it>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=======================================================================
+# (To distribute this file outside of CMake, substitute the full
+# License text for the above reference.)
+
+
+include(CMakeParseArguments)
+
+
+function(ADD_INSTALL_RPATH_SUPPORT)
+
+  set(_options USE_LINK_PATH)
+  set(_oneValueArgs INSTALL_NAME_DIR)
+  set(_multiValueArgs BIN_DIRS
+    LIB_DIRS
+    DEPENDS)
+
+  cmake_parse_arguments(_ARS "${_options}"
+    "${_oneValueArgs}"
+    "${_multiValueArgs}"
+    "${ARGN}")
+
+  # if either RPATH or INSTALL_RPATH is disabled
+  # and the INSTALL_NAME_DIR variable is set, then hardcode the install name
+  if(CMAKE_SKIP_RPATH OR CMAKE_SKIP_INSTALL_RPATH)
+    if(DEFINED _ARS_INSTALL_NAME_DIR)
+      set(CMAKE_INSTALL_NAME_DIR ${_ARS_INSTALL_NAME_DIR} PARENT_SCOPE)
+    endif()
+  endif()
+
+  if (CMAKE_SKIP_RPATH OR (CMAKE_SKIP_INSTALL_RPATH AND CMAKE_SKIP_BUILD_RPATH))
+    return()
+  endif()
+
+
+  set(_rpath_available 1)
+  if(DEFINED _ARS_DEPENDS)
+    foreach(_dep ${_ARS_DEPENDS})
+      string(REGEX REPLACE " +" ";" _dep "${_dep}")
+      if(NOT (${_dep}))
+        set(_rpath_available 0)
+      endif()
+    endforeach()
+  endif()
+
+  if(_rpath_available)
+
+    # Enable RPATH on OSX.
+    set(CMAKE_MACOSX_RPATH TRUE PARENT_SCOPE)
+
+    # Find system implicit lib directories
+    set(_system_lib_dirs ${CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES})
+    if(EXISTS "/etc/debian_version") # is this a debian system ?
+      if(CMAKE_LIBRARY_ARCHITECTURE)
+        list(APPEND _system_lib_dirs "/lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+          "/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}")
+      endif()
+    endif()
+    # This is relative RPATH for libraries built in the same project
+    foreach(lib_dir ${_ARS_LIB_DIRS})
+      list(FIND _system_lib_dirs "${lib_dir}" isSystemDir)
+      if("${isSystemDir}" STREQUAL "-1")
+        foreach(bin_dir ${_ARS_LIB_DIRS} ${_ARS_BIN_DIRS})
+          file(RELATIVE_PATH _rel_path ${bin_dir} ${lib_dir})
+          if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+            list(APPEND CMAKE_INSTALL_RPATH "@loader_path/${_rel_path}")
+          else()
+            list(APPEND CMAKE_INSTALL_RPATH "\$ORIGIN/${_rel_path}")
+          endif()
+        endforeach()
+      endif()
+    endforeach()
+    if(NOT "${CMAKE_INSTALL_RPATH}" STREQUAL "")
+      list(REMOVE_DUPLICATES CMAKE_INSTALL_RPATH)
+    endif()
+    set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} PARENT_SCOPE)
+
+    # add the automatically determined parts of the RPATH
+    # which point to directories outside the build tree to the install RPATH
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ${_ARS_USE_LINK_PATH} PARENT_SCOPE)
+
+  endif()
+
+endfunction()

--- a/cmake/AddLieGroupControllersUnitTest.cmake
+++ b/cmake/AddLieGroupControllersUnitTest.cmake
@@ -1,0 +1,64 @@
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+liegroupcontrollers_dependent_option(LIEGROUPCONTROLLERS_COMPILE_tests
+  "Compile tests?" ON
+  "LIEGROUPCONTROLLERS_HAS_Catch2;BUILD_TESTING" OFF)
+
+liegroupcontrollers_dependent_option(LIEGROUPCONTROLLERS_RUN_Valgrind_tests
+  "Run Valgrind tests?" OFF
+  "LIEGROUPCONTROLLERS_COMPILE_tests;VALGRIND_FOUND" OFF)
+
+if (LIEGROUPCONTROLLERS_RUN_Valgrind_tests)
+    set(CTEST_MEMORYCHECK_COMMAND ${VALGRIND_PROGRAM})
+    set(MEMORYCHECK_COMMAND ${VALGRIND_PROGRAM})
+    set(MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --error-exitcode=1 ${MEMORYCHECK_SUPPRESSIONS}"  CACHE STRING "Options to pass to the memory checker")
+    mark_as_advanced(MEMORYCHECK_COMMAND_OPTIONS)
+    set(MEMCHECK_COMMAND_COMPLETE "${MEMORYCHECK_COMMAND} ${MEMORYCHECK_COMMAND_OPTIONS}")
+    separate_arguments(MEMCHECK_COMMAND_COMPLETE)
+endif()
+
+if (LIEGROUPCONTROLLERS_COMPILE_tests)
+    configure_file(cmake/Catch2Main.cpp.in ${CMAKE_BINARY_DIR}/Testing/Catch2Main.cpp)
+    add_library(CatchTestMain ${CMAKE_BINARY_DIR}/Testing/Catch2Main.cpp)
+    target_link_libraries(CatchTestMain PUBLIC Catch2::Catch2)
+endif()
+
+
+function(add_liegroupcontrollers_test)
+
+    if(LIEGROUPCONTROLLERS_COMPILE_tests)
+
+      set(options)
+      set(oneValueArgs NAME)
+      set(multiValueArgs SOURCES LINKS COMPILE_DEFINITIONS)
+
+      set(prefix "lie_group_controllers")
+
+      cmake_parse_arguments(${prefix}
+          "${options}"
+          "${oneValueArgs}"
+          "${multiValueArgs}"
+          ${ARGN})
+
+      set(name ${${prefix}_NAME})
+      set(unit_test_files ${${prefix}_SOURCES})
+
+      set(targetname ${name}UnitTests)
+      add_executable(${targetname}
+          "${unit_test_files}")
+
+      target_link_libraries(${targetname} PRIVATE CatchTestMain ${${prefix}_LINKS})
+      target_compile_definitions(${targetname} PRIVATE CATCH_CONFIG_FAST_COMPILE CATCH_CONFIG_DISABLE_MATCHERS)
+      target_compile_features(${targetname} PUBLIC cxx_std_14)
+
+      add_test(NAME ${targetname} COMMAND ${targetname})
+      target_compile_definitions(${targetname} PRIVATE ${${prefix}_COMPILE_DEFINITIONS})
+
+      if(LIEGROUPCONTROLLERS_RUN_Valgrind_tests)
+        add_test(NAME memcheck_${targetname} COMMAND ${MEMCHECK_COMMAND_COMPLETE} $<TARGET_FILE:${targetname}>)
+      endif()
+
+    endif()
+
+endfunction()

--- a/cmake/AddUninstallTarget.cmake
+++ b/cmake/AddUninstallTarget.cmake
@@ -1,0 +1,70 @@
+#.rst:
+# AddUninstallTarget
+# ------------------
+#
+# Add the "uninstall" target for your project::
+#
+#   include(AddUninstallTarget)
+#
+#
+# will create a file cmake_uninstall.cmake in the build directory and add a
+# custom target uninstall that will remove the files installed by your package
+# (using install_manifest.txt)
+
+#=============================================================================
+# Copyright 2008-2013 Kitware, Inc.
+# Copyright 2013 iCub Facility, Istituto Italiano di Tecnologia
+#   Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+
+if(DEFINED __ADD_UNINSTALL_TARGET_INCLUDED)
+  return()
+endif()
+set(__ADD_UNINSTALL_TARGET_INCLUDED TRUE)
+
+
+set(_filename ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+
+file(WRITE ${_filename}
+  "if(NOT EXISTS \"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\")
+    message(WARNING \"Cannot find install manifest: \\\"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\\\"\")
+    return()
+endif()
+
+file(READ \"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\" files)
+string(STRIP \"\${files}\" files)
+string(REGEX REPLACE \"\\n\" \";\" files \"\${files}\")
+list(REVERSE files)
+foreach(file \${files})
+    message(STATUS \"Uninstalling: \$ENV{DESTDIR}\${file}\")
+    if(EXISTS \"\$ENV{DESTDIR}\${file}\")
+        execute_process(
+            COMMAND \${CMAKE_COMMAND} -E remove \"\$ENV{DESTDIR}\${file}\"
+            OUTPUT_VARIABLE rm_out
+            RESULT_VARIABLE rm_retval)
+        if(NOT \"\${rm_retval}\" EQUAL 0)
+            message(FATAL_ERROR \"Problem when removing \\\"\$ENV{DESTDIR}\${file}\\\"\")
+        endif()
+    else()
+        message(STATUS \"File \\\"\$ENV{DESTDIR}\${file}\\\" does not exist.\")
+    endif()
+endforeach(file)
+")
+
+if("${CMAKE_GENERATOR}" MATCHES "^(Visual Studio|Xcode)")
+  set(_uninstall "UNINSTALL")
+else()
+  set(_uninstall "uninstall")
+endif()
+add_custom_target(${_uninstall} COMMAND "${CMAKE_COMMAND}" -P "${_filename}")
+set_property(TARGET ${_uninstall} PROPERTY FOLDER "CMakePredefinedTargets")

--- a/cmake/Catch2Main.cpp.in
+++ b/cmake/Catch2Main.cpp.in
@@ -1,0 +1,9 @@
+/**
+ * @file Catch2Main.cpp(.in)
+ * @authors Giulio Romualdi
+ * @copyright This software may be modified and distributed under the terms of the GNU Lesser
+ * General Public License v2.1 or any later version.
+ */
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/cmake/FindVALGRIND.cmake
+++ b/cmake/FindVALGRIND.cmake
@@ -1,0 +1,26 @@
+# Find Valgrind.
+#
+# This module defines:
+#  VALGRIND_INCLUDE_DIR, where to find valgrind/memcheck.h, etc.
+#  VALGRIND_PROGRAM, the valgrind executable.
+#  VALGRIND_FOUND, If false, do not try to use valgrind.
+#
+# If you have valgrind installed in a non-standard place, you can define
+# VALGRIND_ROOT to tell cmake where it is.
+if (VALGRIND_FOUND)
+  return()
+endif()
+
+find_path(VALGRIND_INCLUDE_DIR valgrind/memcheck.h
+  /usr/include /usr/local/include ${VALGRIND_ROOT}/include)
+
+# if VALGRIND_ROOT is empty, we explicitly add /bin to the search
+# path, but this does not hurt...
+find_program(VALGRIND_PROGRAM NAMES valgrind PATH ${VALGRIND_ROOT}/bin)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(VALGRIND DEFAULT_MSG
+  VALGRIND_INCLUDE_DIR
+  VALGRIND_PROGRAM)
+
+mark_as_advanced(VALGRIND_ROOT VALGRIND_INCLUDE_DIR VALGRIND_PROGRAM)

--- a/cmake/InstallBasicPackageFiles.cmake
+++ b/cmake/InstallBasicPackageFiles.cmake
@@ -1,0 +1,681 @@
+#.rst:
+# InstallBasicPackageFiles
+# ------------------------
+#
+# A helper module to make your package easier to be found by other
+# projects.
+#
+#
+# .. command:: install_basic_package_files
+#
+# Create and install a basic version of cmake config files for your
+# project::
+#
+#  install_basic_package_files(<Name>
+#                              VERSION <version>
+#                              COMPATIBILITY <compatibility>
+#                              [EXPORT <export>] # (default = "<Name>")
+#                              [FIRST_TARGET <target1>] # (default = "<Name>")
+#                              [TARGETS <target1> <target2> ...]
+#                              [TARGETS_PROPERTY <property_name>]
+#                              [TARGETS_PROPERTIES <property1_name> <property2_name> ...]
+#                              [NO_SET_AND_CHECK_MACRO]
+#                              [NO_CHECK_REQUIRED_COMPONENTS_MACRO]
+#                              [VARS_PREFIX <prefix>] # (default = "<Name>")
+#                              [EXPORT_DESTINATION <destination>]
+#                              [INSTALL_DESTINATION <destination>]
+#                              [NAMESPACE <namespace>] # (default = "<Name>::")
+#                              [EXTRA_PATH_VARS_SUFFIX path1 [path2 ...]]
+#                              [CONFIG_TEMPLATE <file>]
+#                              [UPPERCASE_FILENAMES | LOWERCASE_FILENAMES]
+#                              [DEPENDENCIES <dependency1> "<dependency2> [...]" ...]
+#                              [PRIVATE_DEPENDENCIES <dependency1> "<dependency2> [...]" ...]
+#                              [INCLUDE_FILE <file>]
+#                              [COMPONENT <component>] # (default = "<Name>")
+#                              [NO_COMPATIBILITY_VARS]
+#                             )
+#
+# Depending on UPPERCASE_FILENAMES and LOWERCASE_FILENAMES, this
+# function generates 3 files:
+#
+#  - ``<Name>ConfigVersion.cmake`` or ``<name>-config-version.cmake``
+#  - ``<Name>Config.cmake`` or ``<name>-config.cmake``
+#  - ``<Name>Targets.cmake`` or ``<name>-targets.cmake``
+#
+# If neither ``UPPERCASE_FILENAMES`` nor ``LOWERCASE_FILENAMES`` is
+# set, a file ``<Name>ConfigVersion.cmake.in`` or
+# ``<name>-config-version.cmake.in`` is searched, and the convention
+# is chosed according to the file found. If no file was found, the
+# uppercase convention is used.
+#
+# The ``DEPENDENCIES`` argument can be used to set a list of dependencies
+# that will be searched using the :command:`find_dependency` command
+# from the :module:`CMakeFindDependencyMacro` module.
+# Dependencies can be followed by any of the possible :command:`find_dependency`
+# argument.
+# In this case, all the arguments must be specified within double quotes (e.g.
+# "<dependency> 1.0.0 EXACT", "<dependency> CONFIG").
+# The ``PRIVATE_DEPENDENCIES`` argument is similar to ``DEPENDENCIES``, but
+# these dependencies are included only when libraries are built ``STATIC``, i.e.
+# if ``BUILD_SHARED_LIBS`` is ``OFF`` or if the ``TYPE`` property for one or
+# more of the targets is ``STATIC_LIBRARY``.
+# When using a custom template file, the ``@PACKAGE_DEPENDENCIES@``
+# string is replaced with the code checking for the dependencies
+# specified by these two argument.
+#
+# Each file is generated twice, one for the build directory and one for
+# the installation directory.  The ``INSTALL_DESTINATION`` argument can be
+# passed to install the files in a location different from the default
+# one (``CMake`` on Windows, ``${CMAKE_INSTALL_LIBDIR}/cmake/${Name}``
+# on other platforms.  The ``EXPORT_DESTINATION`` argument can be passed to
+# generate the files in the build tree in a location different from the default
+# one (``CMAKE_BINARY_DIR``).  If this is a relative path, it is considered
+# relative to the ``CMAKE_BINARY_DIR`` directory.
+#
+# The ``<Name>ConfigVersion.cmake`` is generated using
+# ``write_basic_package_version_file``.  The ``VERSION``,
+# ``COMPATIBILITY``, ``NO_SET_AND_CHECK_MACRO``, and
+# ``NO_CHECK_REQUIRED_COMPONENTS_MACRO`` are passed to this function
+# and are used internally by :module:`CMakePackageConfigHelpers` module.
+#
+# ``VERSION`` shall be in the form ``<major>[.<minor>[.<patch>[.<tweak>]]]]``.
+# If no ``VERSION`` is given, the ``PROJECT_VERSION`` variable is used.
+# If this hasn’t been set, it errors out.  The ``VERSION`` argument is also used
+# to replace the ``@PACKAGE_VERSION@`` string in the configuration file.
+#
+# ``COMPATIBILITY`` shall be any of ``<AnyNewerVersion|SameMajorVersion|
+# ExactVersion>``.
+# The ``COMPATIBILITY`` mode ``AnyNewerVersion`` means that the installed
+# package version will be considered compatible if it is newer or exactly the
+# same as the requested version. This mode should be used for packages which are
+# fully backward compatible, also across major versions.
+# If ``SameMajorVersion`` is used instead, then the behaviour differs from
+# ``AnyNewerVersion`` in that the major version number must be the same as
+# requested, e.g. version 2.0 will not be considered compatible if 1.0 is
+# requested. This mode should be used for packages which guarantee backward
+# compatibility within the same major version. If ``ExactVersion`` is used, then
+# the package is only considered compatible if the requested version matches
+# exactly its own version number (not considering the tweak version). For
+# example, version 1.2.3 of a package is only considered compatible to requested
+# version 1.2.3. This mode is for packages without compatibility guarantees. If
+# your project has more elaborated version matching rules, you will need to
+# write your own custom ConfigVersion.cmake file instead of using this macro.
+#
+# By default ``install_basic_package_files`` also generates the two helper
+# macros ``set_and_check()`` and ``check_required_components()`` into the
+# ``<Name>Config.cmake`` file. ``set_and_check()`` should be used instead of the
+# normal set() command for setting directories and file locations. Additionally
+# to setting the variable it also checks that the referenced file or directory
+# actually exists and fails with a ``FATAL_ERROR`` otherwise. This makes sure
+# that the created ``<Name>Config.cmake`` file does not contain wrong
+# references. When using the ``NO_SET_AND_CHECK_MACRO, this macro is not
+# generated into the ``<Name>Config.cmake`` file.
+#
+# By default, ``install_basic_package_files`` append a call to
+# ``check_required_components(<Name>)`` in <Name>Config.cmake file if the
+# package supports components. This macro checks whether all requested,
+# non-optional components have been found, and if this is not the case, sets the
+# ``<Name>_FOUND`` variable to ``FALSE``, so that the package is considered to
+# be not found. It does that by testing the ``<Name>_<Component>_FOUND``
+# variables for all requested required components. When using the
+# ``NO_CHECK_REQUIRED_COMPONENTS_MACRO`` option, this macro is not generated
+# into the <Name>Config.cmake file.
+#
+# Finally, the files in the build and install directory are exactly the same.
+#
+# See the documentation of :module:`CMakePackageConfigHelpers` module for
+# further information and references therein.
+#
+#
+# The ``<Name>Config.cmake`` is generated using
+# ``configure_package_config_file``.  See the documentation for the
+# :module:`CMakePackageConfigHelpers` module for further information.
+# If the ``CONFIG_TEMPLATE`` argument is passed, the specified file
+# is used as template for generating the configuration file, otherwise
+# this module expects to find a ``<Name>Config.cmake.in`` or
+# ``<name>-config.cmake.in`` file either in the root directory of the
+# project or in current source directory.
+# If the file does not exist, a very basic file is created.
+#
+# A set of variables are checked and passed to
+# ``configure_package_config_file`` as ``PATH_VARS``. For each of the
+# ``SUFFIX`` considered, if one of the variables::
+#
+#     <VARS_PREFIX>_(BUILD|INSTALL)_<SUFFIX>
+#     (BUILD|INSTALL)_<VARS_PREFIX>_<SUFFIX>
+#
+# is defined, the ``<VARS_PREFIX>_<SUFFIX>`` variable will be defined
+# before configuring the package.  In order to use that variable in the
+# config file, you have to add a line::
+#
+#   set_and_check(<VARS_PREFIX>_<SUFFIX> \"@PACKAGE_<VARS_PREFIX>_<SUFFIX>@\")
+#
+# if the path must exist or just::
+#
+#   set(<VARS_PREFIX>_<SUFFIX> \"@PACKAGE_<VARS_PREFIX>_<SUFFIX>@\")
+#
+# if the path could be missing.
+#
+# These variable will have different values whether you are using the
+# package from the build tree or from the install directory.  Also these
+# files will contain only relative paths, meaning that you can move the
+# whole installation and the CMake files will still work.
+#
+# Default ``PATH_VARS`` suffixes are::
+#
+#   BINDIR          BIN_DIR
+#   SBINDIR         SBIN_DIR
+#   LIBEXECDIR      LIBEXEC_DIR
+#   SYSCONFDIR      SYSCONF_DIR
+#   SHAREDSTATEDIR  SHAREDSTATE_DIR
+#   LOCALSTATEDIR   LOCALSTATE_DIR
+#   LIBDIR          LIB_DIR
+#   INCLUDEDIR      INCLUDE_DIR
+#   OLDINCLUDEDIR   OLDINCLUDE_DIR
+#   DATAROOTDIR     DATAROOT_DIR
+#   DATADIR         DATA_DIR
+#   INFODIR         INFO_DIR
+#   LOCALEDIR       LOCALE_DIR
+#   MANDIR          MAN_DIR
+#   DOCDIR          DOC_DIR
+#
+# more suffixes can be added using the ``EXTRA_PATH_VARS_SUFFIX``
+# argument.
+#
+#
+# The ``<Name>Targets.cmake`` is generated using
+# :command:`export(TARGETS)` (if ``EXPORT`` or no options are used) or
+# :command:`export(TARGETS)` (if `EXPORT` is not used and one between
+# ``TARGETS``, ``TARGETS_PROPERTY``, or ``TARGETS_PROPERTIES`` is used) in the
+# build tree and :command:`install(EXPORT)` in the installation directory.
+# The targets are exported using the value for the ``NAMESPACE``
+# argument as namespace.
+# The export can be passed using the `EXPORT` argument.
+# The targets can be passed using the `TARGETS` argument or using one or more
+# global properties, that can be passed to the function using the
+# ``TARGETS_PROPERTY`` or ``TARGET_PROPERTIES`` arguments.
+#
+# If the ``NO_COMPATIBILITY_VARS`` argument is not set, the compatibility
+# variables ``<VARS_PREFIX>_LIBRARIES`` and ``<VARS_PREFIX>_INCLUDE_DIRS``
+# are set, trying to guess their correct values from the variables set or
+# from the arguments passed to this command. This argument is ignored if
+# the template file is not generated by this command.
+#
+# If the ``INCLUDE_FILE`` argument is passed, the content of the specified file
+# (which might be templated) is appended to the ``<Name>Config.cmake``.
+# This allows to inject custom code to this file, useful e.g. to set additional
+# variables which are loaded by downstream projects.
+#
+# If the ``COMPONENT`` argument is passed, it is forwarded to the
+# :command:`install` commands, otherwise <Name> is used.
+
+#=============================================================================
+# Copyright 2013 Istituto Italiano di Tecnologia (IIT)
+#   Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+
+if(COMMAND install_basic_package_files)
+  return()
+endif()
+
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+include(CMakeParseArguments)
+
+
+function(INSTALL_BASIC_PACKAGE_FILES _Name)
+
+  # TODO check that _Name does not contain "-" characters
+
+  set(_options NO_SET_AND_CHECK_MACRO
+               NO_CHECK_REQUIRED_COMPONENTS_MACRO
+               UPPERCASE_FILENAMES
+               LOWERCASE_FILENAMES
+               NO_COMPATIBILITY_VARS)
+  set(_oneValueArgs VERSION
+                    COMPATIBILITY
+                    EXPORT
+                    FIRST_TARGET
+                    TARGETS_PROPERTY
+                    VARS_PREFIX
+                    EXPORT_DESTINATION
+                    INSTALL_DESTINATION
+                    DESTINATION
+                    NAMESPACE
+                    CONFIG_TEMPLATE
+                    INCLUDE_FILE
+                    COMPONENT)
+  set(_multiValueArgs EXTRA_PATH_VARS_SUFFIX
+                      TARGETS
+                      TARGETS_PROPERTIES
+                      DEPENDENCIES
+                      PRIVATE_DEPENDENCIES)
+  cmake_parse_arguments(_IBPF "${_options}" "${_oneValueArgs}" "${_multiValueArgs}" "${ARGN}")
+
+  if(NOT DEFINED _IBPF_VARS_PREFIX)
+    set(_IBPF_VARS_PREFIX ${_Name})
+  endif()
+
+  if(NOT DEFINED _IBPF_VERSION)
+    message(FATAL_ERROR "VERSION argument is required")
+  endif()
+
+  if(NOT DEFINED _IBPF_COMPATIBILITY)
+    message(FATAL_ERROR "COMPATIBILITY argument is required")
+  endif()
+
+  if(_IBPF_UPPERCASE_FILENAMES AND _IBPF_LOWERCASE_FILENAMES)
+    message(FATAL_ERROR "UPPERCASE_FILENAMES and LOWERCASE_FILENAMES arguments cannot be used together")
+  endif()
+
+  # Prepare install and export commands
+  set(_first_target ${_Name})
+  set(_targets ${_Name})
+  set(_install_cmd EXPORT ${_Name})
+  set(_export_cmd EXPORT ${_Name})
+
+  if(DEFINED _IBPF_FIRST_TARGET)
+    if(DEFINED _IBPF_TARGETS OR DEFINED _IBPF_TARGETS_PROPERTIES OR DEFINED _IBPF_TARGETS_PROPERTIES)
+      message(FATAL_ERROR "EXPORT cannot be used with TARGETS, TARGETS_PROPERTY or TARGETS_PROPERTIES")
+    endif()
+
+    set(_first_target ${_IBPF_FIRST_TARGET})
+    set(_targets ${_IBPF_FIRST_TARGET})
+  endif()
+
+  if(DEFINED _IBPF_EXPORT)
+    if(DEFINED _IBPF_TARGETS OR DEFINED _IBPF_TARGETS_PROPERTIES OR DEFINED _IBPF_TARGETS_PROPERTIES)
+      message(FATAL_ERROR "EXPORT cannot be used with TARGETS, TARGETS_PROPERTY or TARGETS_PROPERTIES")
+    endif()
+
+    set(_export_cmd EXPORT ${_IBPF_EXPORT})
+    set(_install_cmd EXPORT ${_IBPF_EXPORT})
+
+  elseif(DEFINED _IBPF_TARGETS)
+    if(DEFINED _IBPF_TARGETS_PROPERTY OR DEFINED _IBPF_TARGETS_PROPERTIES)
+      message(FATAL_ERROR "TARGETS cannot be used with TARGETS_PROPERTY or TARGETS_PROPERTIES")
+    endif()
+
+    set(_targets ${_IBPF_TARGETS})
+    set(_export_cmd TARGETS ${_IBPF_TARGETS})
+    list(GET _targets 0 _first_target)
+
+  elseif(DEFINED _IBPF_TARGETS_PROPERTY)
+    if(DEFINED _IBPF_TARGETS_PROPERTIES)
+      message(FATAL_ERROR "TARGETS_PROPERTIES cannot be used with TARGETS_PROPERTIES")
+    endif()
+
+    get_property(_targets GLOBAL PROPERTY ${_IBPF_TARGETS_PROPERTY})
+    set(_export_cmd TARGETS ${_targets})
+    list(GET _targets 0 _first_target)
+
+  elseif(DEFINED _IBPF_TARGETS_PROPERTIES)
+
+    unset(_targets)
+    foreach(_prop ${_IBPF_TARGETS_PROPERTIES})
+      get_property(_prop_val GLOBAL PROPERTY ${_prop})
+      list(APPEND _targets ${_prop_val})
+    endforeach()
+    set(_export_cmd TARGETS ${_targets})
+    list(GET _targets 0 _first_target)
+
+  endif()
+
+  # Path for installed cmake files
+  if(DEFINED _IBPF_DESTINATION)
+    message(DEPRECATION "DESTINATION is deprecated. Use INSTALL_DESTINATION instead")
+    if(NOT DEFINED _IBPF_INSTALL_DESTINATION)
+      set(_IBPF_INSTALL_DESTINATION ${_IBPF_DESTINATION})
+    endif()
+  endif()
+
+  if(NOT DEFINED _IBPF_INSTALL_DESTINATION)
+    if(WIN32 AND NOT CYGWIN)
+      set(_IBPF_INSTALL_DESTINATION CMake)
+    else()
+      set(_IBPF_INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${_Name})
+    endif()
+  endif()
+
+  if(NOT DEFINED _IBPF_EXPORT_DESTINATION)
+    set(_IBPF_EXPORT_DESTINATION "${CMAKE_BINARY_DIR}")
+  elseif(NOT IS_ABSOLUTE _IBPF_EXPORT_DESTINATION)
+    set(_IBPF_EXPORT_DESTINATION "${CMAKE_BINARY_DIR}/${_IBPF_EXPORT_DESTINATION}")
+  endif()
+
+  if(NOT DEFINED _IBPF_NAMESPACE)
+    set(_IBPF_NAMESPACE "${_Name}::")
+  endif()
+
+  if(NOT DEFINED _IBPF_COMPONENT)
+    set(_IBPF_COMPONENT "${_Name}")
+  endif()
+
+  if(_IBPF_NO_SET_AND_CHECK_MACRO)
+    list(APPEND configure_package_config_file_extra_args NO_SET_AND_CHECK_MACRO)
+  endif()
+
+  if(_IBPF_NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+    list(APPEND configure_package_config_file_extra_args NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+  endif()
+
+
+
+  # Set input file for config, and ensure that _IBPF_UPPERCASE_FILENAMES
+  # and _IBPF_LOWERCASE_FILENAMES are set correctly
+  unset(_config_cmake_in)
+  set(_generate_file 0)
+  if(DEFINED _IBPF_CONFIG_TEMPLATE)
+    if(NOT EXISTS "${_IBPF_CONFIG_TEMPLATE}")
+      message(FATAL_ERROR "Config template file \"${_IBPF_CONFIG_TEMPLATE}\" not found")
+    endif()
+    set(_config_cmake_in "${_IBPF_CONFIG_TEMPLATE}")
+    if(NOT _IBPF_UPPERCASE_FILENAMES AND NOT _IBPF_LOWERCASE_FILENAMES)
+      if("${_IBPF_CONFIG_TEMPLATE}" MATCHES "${_Name}Config.cmake.in")
+        set(_IBPF_UPPERCASE_FILENAMES 1)
+      elseif("${_IBPF_CONFIG_TEMPLATE}" MATCHES "${_name}-config.cmake.in")
+        set(_IBPF_LOWERCASE_FILENAMES 1)
+      else()
+        set(_IBPF_UPPERCASE_FILENAMES 1)
+      endif()
+    endif()
+  else()
+    string(TOLOWER "${_Name}" _name)
+    if(EXISTS "${CMAKE_SOURCE_DIR}/${_Name}Config.cmake.in")
+      set(_config_cmake_in "${CMAKE_SOURCE_DIR}/${_Name}Config.cmake.in")
+      if(NOT _IBPF_UPPERCASE_FILENAMES AND NOT _IBPF_LOWERCASE_FILENAMES)
+        set(_IBPF_UPPERCASE_FILENAMES 1)
+      endif()
+    elseif(EXISTS "${CMAKE_SOURCE_DIR}/${_name}-config.cmake.in")
+      set(_config_cmake_in "${CMAKE_SOURCE_DIR}/${_name}-config.cmake.in")
+      if(NOT _IBPF_UPPERCASE_FILENAMES AND NOT _IBPF_LOWERCASE_FILENAMES)
+        set(_IBPF_LOWERCASE_FILENAMES 1)
+      endif()
+    elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${_Name}Config.cmake.in")
+      set(_config_cmake_in "${CMAKE_CURRENT_SOURCE_DIR}/${_Name}Config.cmake.in")
+      if(NOT _IBPF_UPPERCASE_FILENAMES AND NOT _IBPF_LOWERCASE_FILENAMES)
+        set(_IBPF_UPPERCASE_FILENAMES 1)
+      endif()
+    elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${_name}-config.cmake.in")
+      set(_config_cmake_in "${CMAKE_CURRENT_SOURCE_DIR}/${_name}-config.cmake.in")
+      if(NOT _IBPF_UPPERCASE_FILENAMES AND NOT _IBPF_LOWERCASE_FILENAMES)
+        set(_IBPF_LOWERCASE_FILENAMES 1)
+      endif()
+    else()
+      set(_generate_file 1)
+      if(_IBPF_LOWERCASE_FILENAMES)
+        set(_config_cmake_in "${CMAKE_CURRENT_BINARY_DIR}/${_name}-config.cmake")
+      else()
+        set(_config_cmake_in "${CMAKE_CURRENT_BINARY_DIR}/${_Name}Config.cmake.in")
+        set(_IBPF_UPPERCASE_FILENAMES 1)
+      endif()
+    endif()
+  endif()
+
+  # Set input file containing user variables
+  if(DEFINED _IBPF_INCLUDE_FILE)
+    if(NOT IS_ABSOLUTE "${_IBPF_INCLUDE_FILE}")
+      if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${_IBPF_INCLUDE_FILE}")
+        set(_IBPF_INCLUDE_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${_IBPF_INCLUDE_FILE}")
+      endif()
+    endif()
+    if(NOT EXISTS "${_IBPF_INCLUDE_FILE}")
+        message(FATAL_ERROR "File \"${_IBPF_INCLUDE_FILE}\" not found")
+    endif()
+    file(READ ${_IBPF_INCLUDE_FILE} _includedfile_user_content_in)
+    string(CONFIGURE ${_includedfile_user_content_in} _includedfile_user_content)
+    set(INCLUDED_FILE_CONTENT
+"#### Expanded from INCLUDE_FILE by install_basic_package_files() ####")
+    set(INCLUDED_FILE_CONTENT "${INCLUDED_FILE_CONTENT}\n\n${_includedfile_user_content}")
+    set(INCLUDED_FILE_CONTENT
+"${INCLUDED_FILE_CONTENT}
+#####################################################################")
+  endif()
+
+  # Select output file names
+  if(_IBPF_UPPERCASE_FILENAMES)
+    set(_config_filename ${_Name}Config.cmake)
+    set(_version_filename ${_Name}ConfigVersion.cmake)
+    set(_targets_filename ${_Name}Targets.cmake)
+  elseif(_IBPF_LOWERCASE_FILENAMES)
+    set(_config_filename ${_name}-config.cmake)
+    set(_version_filename ${_name}-config-version.cmake)
+    set(_targets_filename ${_name}-targets.cmake)
+  endif()
+
+
+  # If the template config file does not exist, write a basic one
+  if(_generate_file)
+    # Generate the compatibility code
+    unset(_compatibility_vars)
+    if(NOT _IBPF_NO_COMPATIBILITY_VARS)
+      unset(_get_include_dir_code)
+      unset(_set_include_dir_code)
+      unset(_target_list)
+      foreach(_target ${_targets})
+        list(APPEND _target_list ${_IBPF_NAMESPACE}${_target})
+      endforeach()
+      if(DEFINED ${_IBPF_VARS_PREFIX}_BUILD_INCLUDEDIR OR
+         DEFINED BUILD_${_IBPF_VARS_PREFIX}_INCLUDEDIR OR
+         DEFINED ${_IBPF_VARS_PREFIX}_INSTALL_INCLUDEDIR OR
+         DEFINED INSTALL_${_IBPF_VARS_PREFIX}_INCLUDEDIR)
+        set(_get_include_dir "set(${_IBPF_VARS_PREFIX}_INCLUDEDIR \"\@PACKAGE_${_IBPF_VARS_PREFIX}_INCLUDEDIR\@\")\n")
+        set(_set_include_dir "set(${_Name}_INCLUDE_DIRS \"\${${_IBPF_VARS_PREFIX}_INCLUDEDIR}\")")
+      elseif(DEFINED ${_IBPF_VARS_PREFIX}_BUILD_INCLUDE_DIR OR
+             DEFINED BUILD_${_IBPF_VARS_PREFIX}_INCLUDE_DIR OR
+             DEFINED ${_IBPF_VARS_PREFIX}_INSTALL_INCLUDE_DIR OR
+             DEFINED INSTALL_${_IBPF_VARS_PREFIX}_INCLUDE_DIR)
+        set(_get_include_dir "set(${_IBPF_VARS_PREFIX}_INCLUDE_DIR \"\@PACKAGE_${_IBPF_VARS_PREFIX}_INCLUDE_DIR\@\")\n")
+        set(_set_include_dir "set(${_Name}_INCLUDE_DIRS \"\${${_IBPF_VARS_PREFIX}_INCLUDE_DIR}\")")
+      else()
+        unset(_include_dir_list)
+        foreach(_target ${_targets})
+          set(_get_include_dir "${_get_include_dir}get_property(${_IBPF_VARS_PREFIX}_${_target}_INCLUDE_DIR TARGET ${_IBPF_NAMESPACE}${_target} PROPERTY INTERFACE_INCLUDE_DIRECTORIES)\n")
+          list(APPEND _include_dir_list "\"\${${_IBPF_VARS_PREFIX}_${_target}_INCLUDE_DIR}\"")
+        endforeach()
+        string(REPLACE ";" " " _include_dir_list "${_include_dir_list}")
+        string(REPLACE ";" " " _target_list "${_target_list}")
+        set(_set_include_dir "set(${_Name}_INCLUDE_DIRS ${_include_dir_list})\nlist(REMOVE_DUPLICATES ${_Name}_INCLUDE_DIRS)")
+      endif()
+      set(_compatibility_vars "# Compatibility\n${_get_include_dir}\nset(${_Name}_LIBRARIES ${_target_list})\n${_set_include_dir}")
+    endif()
+
+    # Write the file
+    file(WRITE "${_config_cmake_in}"
+"set(${_IBPF_VARS_PREFIX}_VERSION \@PACKAGE_VERSION\@)
+
+\@PACKAGE_INIT\@
+
+\@PACKAGE_DEPENDENCIES\@
+
+if(NOT TARGET ${_IBPF_NAMESPACE}${_first_target})
+  include(\"\${CMAKE_CURRENT_LIST_DIR}/${_targets_filename}\")
+endif()
+
+${_compatibility_vars}
+
+\@INCLUDED_FILE_CONTENT\@
+")
+  endif()
+
+  # Make relative paths absolute (needed later on) and append the
+  # defined variables to _(build|install)_path_vars_suffix
+  foreach(p BINDIR          BIN_DIR
+            SBINDIR         SBIN_DIR
+            LIBEXECDIR      LIBEXEC_DIR
+            SYSCONFDIR      SYSCONF_DIR
+            SHAREDSTATEDIR  SHAREDSTATE_DIR
+            LOCALSTATEDIR   LOCALSTATE_DIR
+            LIBDIR          LIB_DIR
+            INCLUDEDIR      INCLUDE_DIR
+            OLDINCLUDEDIR   OLDINCLUDE_DIR
+            DATAROOTDIR     DATAROOT_DIR
+            DATADIR         DATA_DIR
+            INFODIR         INFO_DIR
+            LOCALEDIR       LOCALE_DIR
+            MANDIR          MAN_DIR
+            DOCDIR          DOC_DIR
+            ${_IBPF_EXTRA_PATH_VARS_SUFFIX})
+    if(DEFINED ${_IBPF_VARS_PREFIX}_BUILD_${p})
+      list(APPEND _build_path_vars_suffix ${p})
+      list(APPEND _build_path_vars "${_IBPF_VARS_PREFIX}_${p}")
+    endif()
+    if(DEFINED BUILD_${_IBPF_VARS_PREFIX}_${p})
+      list(APPEND _build_path_vars_suffix ${p})
+      list(APPEND _build_path_vars "${_IBPF_VARS_PREFIX}_${p}")
+    endif()
+    if(DEFINED ${_IBPF_VARS_PREFIX}_INSTALL_${p})
+      list(APPEND _install_path_vars_suffix ${p})
+      list(APPEND _install_path_vars "${_IBPF_VARS_PREFIX}_${p}")
+    endif()
+    if(DEFINED INSTALL_${_IBPF_VARS_PREFIX}_${p})
+      list(APPEND _install_path_vars_suffix ${p})
+      list(APPEND _install_path_vars "${_IBPF_VARS_PREFIX}_${p}")
+    endif()
+  endforeach()
+
+
+  # <Name>ConfigVersion.cmake file (same for build tree and intall)
+  write_basic_package_version_file("${_IBPF_EXPORT_DESTINATION}/${_version_filename}"
+                                   VERSION ${_IBPF_VERSION}
+                                   COMPATIBILITY ${_IBPF_COMPATIBILITY})
+  install(FILES "${_IBPF_EXPORT_DESTINATION}/${_version_filename}"
+          DESTINATION ${_IBPF_INSTALL_DESTINATION}
+          COMPONENT ${_IBPF_COMPONENT})
+
+
+  # Prepare PACKAGE_DEPENDENCIES variable
+  set(_need_private_deps 0)
+  if(NOT BUILD_SHARED_LIBS)
+    set(_need_private_deps 1)
+  else()
+    foreach(_target ${_targets})
+      get_property(_type TARGET ${_target} PROPERTY TYPE)
+      if("${_type}" STREQUAL "STATIC_LIBRARY")
+        set(_need_private_deps 1)
+        break()
+      endif()
+    endforeach()
+  endif()
+
+  unset(PACKAGE_DEPENDENCIES)
+  if(DEFINED _IBPF_DEPENDENCIES)
+    set(PACKAGE_DEPENDENCIES "#### Expanded from @PACKAGE_DEPENDENCIES@ by install_basic_package_files() ####\n\ninclude(CMakeFindDependencyMacro)\n")
+    string(APPEND PACKAGE_DEPENDENCIES "set(CMAKE_MODULE_PATH_BK \${CMAKE_MODULE_PATH})\n")
+    string(REPLACE ";" " " _this_module_path "${CMAKE_MODULE_PATH}")
+    string(APPEND PACKAGE_DEPENDENCIES "set(CMAKE_MODULE_PATH ${_this_module_path})\n")
+
+    # FIXME When CMake 3.9 or greater is required, remove this madness and just
+    #       use find_dependency
+    if (CMAKE_VERSION VERSION_LESS 3.9)
+      string(APPEND PACKAGE_DEPENDENCIES "
+set(_${_Name}_FIND_PARTS_REQUIRED)
+if (${_Name}_FIND_REQUIRED)
+  set(_${_Name}_FIND_PARTS_REQUIRED REQUIRED)
+endif()
+set(_${_Name}_FIND_PARTS_QUIET)
+if (${_Name}_FIND_QUIETLY)
+  set(_${_Name}_FIND_PARTS_QUIET QUIET)
+endif()
+")
+
+      foreach(_dep ${_IBPF_DEPENDENCIES})
+        if("${_dep}" MATCHES ".+ .+")
+            string(REPLACE " " ";" _dep_list "${_dep}")
+            list(INSERT _dep_list 1 \${_${_Name}_FIND_PARTS_QUIET} \${_${_Name}_FIND_PARTS_REQUIRED})
+            string(REPLACE ";" " " _depx "${_dep_list}")
+            string(APPEND PACKAGE_DEPENDENCIES "find_package(${_depx})\n")
+        else()
+          string(APPEND PACKAGE_DEPENDENCIES "find_dependency(${_dep})\n")
+        endif()
+      endforeach()
+      if(_need_private_deps)
+        foreach(_dep ${_IBPF_PRIVATE_DEPENDENCIES})
+          if("${_dep}" MATCHES ".+ .+")
+            string(REPLACE " " ";" _dep_list "${_dep}")
+            list(INSERT _dep_list 1 \${_${_Name}_FIND_PARTS_QUIET} \${_${_Name}_FIND_PARTS_REQUIRED})
+            string(REPLACE ";" "\n       " _depx "${_dep_list}")
+            string(APPEND PACKAGE_DEPENDENCIES "find_package(${_depx})\n")
+          else()
+            string(APPEND PACKAGE_DEPENDENCIES "find_dependency(${_dep})\n")
+          endif()
+          endforeach()
+      endif()
+
+    else()
+
+      foreach(_dep ${_IBPF_DEPENDENCIES})
+        string(APPEND PACKAGE_DEPENDENCIES "find_dependency(${_dep})\n")
+      endforeach()
+      if(_need_private_deps)
+        foreach(_dep ${_IBPF_PRIVATE_DEPENDENCIES})
+          string(APPEND PACKAGE_DEPENDENCIES "find_dependency(${_dep})\n")
+        endforeach()
+      endif()
+
+    endif()
+    string(APPEND PACKAGE_DEPENDENCIES "set(CMAKE_MODULE_PATH \${CMAKE_MODULE_PATH_BK})\n")
+
+    set(PACKAGE_DEPENDENCIES "${PACKAGE_DEPENDENCIES}\n###############################################################################\n")
+  endif()
+
+  # Prepare PACKAGE_VERSION variable
+  set(PACKAGE_VERSION ${_IBPF_VERSION})
+
+  # <Name>Config.cmake (build tree)
+  foreach(p ${_build_path_vars_suffix})
+    if(DEFINED ${_IBPF_VARS_PREFIX}_BUILD_${p})
+      set(${_IBPF_VARS_PREFIX}_${p} "${${_IBPF_VARS_PREFIX}_BUILD_${p}}")
+    elseif(DEFINED BUILD_${_IBPF_VARS_PREFIX}_${p})
+      set(${_IBPF_VARS_PREFIX}_${p} "${BUILD_${_IBPF_VARS_PREFIX}_${p}}")
+    endif()
+  endforeach()
+  configure_package_config_file("${_config_cmake_in}"
+                                "${_IBPF_EXPORT_DESTINATION}/${_config_filename}"
+                                INSTALL_DESTINATION ${_IBPF_EXPORT_DESTINATION}
+                                PATH_VARS ${_build_path_vars}
+                                ${configure_package_config_file_extra_args}
+                                INSTALL_PREFIX ${CMAKE_BINARY_DIR})
+
+  # <Name>Config.cmake (installed)
+  foreach(p ${_install_path_vars_suffix})
+    if(DEFINED ${_IBPF_VARS_PREFIX}_INSTALL_${p})
+      set(${_IBPF_VARS_PREFIX}_${p} "${${_IBPF_VARS_PREFIX}_INSTALL_${p}}")
+    elseif(DEFINED INSTALL_${_IBPF_VARS_PREFIX}_${p})
+      set(${_IBPF_VARS_PREFIX}_${p} "${INSTALL_${_IBPF_VARS_PREFIX}_${p}}")
+    endif()
+  endforeach()
+  configure_package_config_file("${_config_cmake_in}"
+                                "${CMAKE_CURRENT_BINARY_DIR}/${_config_filename}.install"
+                                INSTALL_DESTINATION ${_IBPF_INSTALL_DESTINATION}
+                                PATH_VARS ${_install_path_vars}
+                                ${configure_package_config_file_extra_args})
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${_config_filename}.install"
+          DESTINATION ${_IBPF_INSTALL_DESTINATION}
+          RENAME ${_config_filename}
+          COMPONENT ${_IBPF_COMPONENT})
+
+
+  # <Name>Targets.cmake (build tree)
+  export(${_export_cmd}
+         NAMESPACE ${_IBPF_NAMESPACE}
+         FILE "${_IBPF_EXPORT_DESTINATION}/${_targets_filename}")
+
+  # <Name>Targets.cmake (installed)
+  install(${_install_cmd}
+          NAMESPACE ${_IBPF_NAMESPACE}
+          DESTINATION ${_IBPF_INSTALL_DESTINATION}
+          FILE "${_targets_filename}"
+          COMPONENT ${_IBPF_COMPONENT})
+endfunction()

--- a/cmake/LieGroupControllersDependencies.cmake
+++ b/cmake/LieGroupControllersDependencies.cmake
@@ -1,0 +1,7 @@
+# Authors: Giulio Romualdi
+# CopyPolicy: Released under the terms of the LGPLv2.1 or later
+
+#---------------------------------------------
+## Required Dependencies
+find_package(Eigen3 3.2.92 REQUIRED)
+find_package(manif REQUIRED)

--- a/cmake/LieGroupControllersDependencies.cmake
+++ b/cmake/LieGroupControllersDependencies.cmake
@@ -1,7 +1,17 @@
 # Authors: Giulio Romualdi
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later
 
+include(LieGroupControllersFindOptionalDependencies)
+
 #---------------------------------------------
 ## Required Dependencies
 find_package(Eigen3 3.2.92 REQUIRED)
 find_package(manif REQUIRED)
+
+#---------------------------------------------
+## Optional Dependencies
+find_package(Catch2 QUIET)
+checkandset_optional_dependency(Catch2)
+
+find_package(VALGRIND QUIET)
+checkandset_optional_dependency(VALGRIND)

--- a/cmake/LieGroupControllersFindOptionalDependencies.cmake
+++ b/cmake/LieGroupControllersFindOptionalDependencies.cmake
@@ -1,0 +1,104 @@
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+#
+# This module checks if all the dependencies are installed and if the
+# dependencies to build some parts are satisfied.
+# For every dependency, it creates the following variables:
+#
+# LIEGROUPCONTROLLERS_USE_${Package}: Can be disabled by the user if he doesn't want to use that
+#                      dependency.
+# LIEGROUPCONTROLLERS_HAS_${Package}: Internal flag. It should be used to check if a part of
+#                      LIEGROUPCONTROLLERS should be built. It is on if LIEGROUPCONTROLLERS_USE_${Package}
+#                      is on and either the package was found or will be built.
+# LIEGROUPCONTROLLERS_BUILD_${Package}: Internal flag. Used to check if LIEGROUPCONTROLLERS has to build an
+#                        external package.
+# LIEGROUPCONTROLLERS_BUILD_DEPS_${Package}: Internal flag. Used to check if dependencies
+#                             required to build the package are available.
+# LIEGROUPCONTROLLERS_HAS_SYSTEM_${Package}: Internal flag. Used to check if the package is
+#                             available on the system.
+# LIEGROUPCONTROLLERS_USE_SYSTEM_${Package}: This flag is shown only for packages in the
+#                             extern folder that were also found on the system
+#                             (TRUE by default). If this flag is enabled, the
+#                             system installed library will be used instead of
+#                             the version shipped within the framework.
+
+
+include(CMakeDependentOption)
+
+# Check if a package is installed and set some cmake variables
+macro(checkandset_optional_dependency package)
+
+  set(PREFIX "LIEGROUPCONTROLLERS")
+
+  string(TOUPPER ${package} PKG)
+
+  # LIEGROUPCONTROLLERS_HAS_SYSTEM_${package}
+  if(${package}_FOUND OR ${PKG}_FOUND)
+    set(${PREFIX}_HAS_SYSTEM_${package} TRUE)
+  else()
+    set(${PREFIX}_HAS_SYSTEM_${package} FALSE)
+  endif()
+
+  # LIEGROUPCONTROLLERS_USE_${package}
+  cmake_dependent_option(${PREFIX}_USE_${package} "Use package ${package}" TRUE
+                         ${PREFIX}_HAS_SYSTEM_${package} FALSE)
+  mark_as_advanced(${PREFIX}_USE_${package})
+
+  # LIEGROUPCONTROLLERS_USE_SYSTEM_${package}
+  set(${PREFIX}_USE_SYSTEM_${package} ${${PREFIX}_USE_${package}} CACHE INTERNAL "Use system-installed ${package}, rather than a private copy (recommended)" FORCE)
+  if(NOT "${package}" STREQUAL "${PKG}")
+    unset(${PREFIX}_USE_SYSTEM_${PKG} CACHE)
+  endif()
+
+  # LIEGROUPCONTROLLERS_HAS_${package}
+  if(${${PREFIX}_HAS_SYSTEM_${package}})
+    set(${PREFIX}_HAS_${package} ${${PREFIX}_USE_${package}})
+  else()
+    set(${PREFIX}_HAS_${package} FALSE)
+  endif()
+
+endmacro()
+
+macro(LIEGROUPCONTROLLERS_DEPENDENT_OPTION _option _doc _default _deps _force)
+
+  if(DEFINED ${_option})
+    get_property(_option_strings_set CACHE ${_option} PROPERTY STRINGS SET)
+    if(_option_strings_set)
+      # If the user thinks he is smarter than the machine, he deserves an error
+      get_property(_option_strings CACHE ${_option} PROPERTY STRINGS)
+      list(GET _option_strings 0 _option_strings_first)
+      string(REGEX REPLACE ".+\"(.+)\".+" "\\1" _option_strings_first "${_option_strings_first}")
+      list(LENGTH _option_strings _option_strings_length)
+      math(EXPR _option_strings_last_index "${_option_strings_length} - 1")
+      list(GET _option_strings ${_option_strings_last_index} _option_strings_last)
+      if("${${_option}}" STREQUAL "${_option_strings_last}")
+        message(SEND_ERROR "That was a trick, you cannot outsmart me! I will never let you win! ${_option} stays OFF until I say so! \"${_option_strings_first}\" is needed to enable ${_option}. Now stop bothering me, and install your dependencies, if you really want to enable this option.")
+      endif()
+      unset(${_option} CACHE)
+    endif()
+  endif()
+
+  cmake_dependent_option(${_option} "${_doc}" ${_default} "${_deps}" ${_force})
+
+  unset(_missing_deps)
+  foreach(_dep ${_deps})
+    string(REGEX REPLACE " +" ";" _depx "${_dep}")
+    if(NOT (${_depx}))
+      list(APPEND _missing_deps "${_dep}")
+    endif()
+  endforeach()
+
+  if(DEFINED _missing_deps)
+    set(${_option}_disable_reason " (dependencies unsatisfied: \"${_missing_deps}\")")
+    # Set a value that can be visualized on ccmake and on cmake-gui, but
+    # still evaluates to false
+    set(${_option} "OFF - Dependencies unsatisfied: '${_missing_deps}' - ${_option}-NOTFOUND" CACHE STRING "${_option_doc}" FORCE)
+    string(REPLACE ";" "\;" _missing_deps "${_missing_deps}")
+
+    # Set non-cache variable that will override the value in current scope
+    # For parent scopes, the "-NOTFOUND ensures that the variable still
+    # evaluates to false
+    set(${_option} ${_force})
+  endif()
+
+endmacro()

--- a/include/LieGroupControllers/ProportionalController.h
+++ b/include/LieGroupControllers/ProportionalController.h
@@ -1,0 +1,19 @@
+/**
+ * @file ProportinalController.h
+ * @authors Giulio Romualdi
+ * @copyright This software may be modified and  distributed under the terms of
+ * the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef LIE_GROUP_CONTROLLERS_PROPORTIONAL_CONTROLLER_H
+#define LIE_GROUP_CONTROLLERS_PROPORTIONAL_CONTROLLER_H
+
+#include <LieGroupControllers/impl/ProportionalController/ProportionalController.h>
+
+namespace LieGroupControllers
+{
+    using ProportinalControllerSO3 = ProportionalController<manif::SO3d>;
+    using ProportinalControllerSE3 = ProportionalController<manif::SE3d>;
+}
+
+#endif

--- a/include/LieGroupControllers/ProportionalController.h
+++ b/include/LieGroupControllers/ProportionalController.h
@@ -1,5 +1,5 @@
 /**
- * @file ProportinalController.h
+ * @file ProportionalController.h
  * @authors Giulio Romualdi
  * @copyright This software may be modified and  distributed under the terms of
  * the GNU Lesser General Public License v2.1 or any later version.
@@ -8,12 +8,12 @@
 #ifndef LIE_GROUP_CONTROLLERS_PROPORTIONAL_CONTROLLER_H
 #define LIE_GROUP_CONTROLLERS_PROPORTIONAL_CONTROLLER_H
 
-#include <LieGroupControllers/impl/ProportionalController/ProportionalController.h>
+#include <LieGroupControllers/impl/ProportionalController/Controller.h>
 
 namespace LieGroupControllers
 {
-    using ProportinalControllerSO3 = ProportionalController<manif::SO3d>;
-    using ProportinalControllerSE3 = ProportionalController<manif::SE3d>;
+    using ProportionalControllerSO3 = ProportionalController<manif::SO3d>;
+    using ProportionalControllerSE3 = ProportionalController<manif::SE3d>;
 }
 
 #endif

--- a/include/LieGroupControllers/ProportionalController.h
+++ b/include/LieGroupControllers/ProportionalController.h
@@ -12,8 +12,8 @@
 
 namespace LieGroupControllers
 {
-    using ProportionalControllerSO3 = ProportionalController<manif::SO3d>;
-    using ProportionalControllerSE3 = ProportionalController<manif::SE3d>;
+    using ProportionalControllerSO3d = ProportionalController<manif::SO3d>;
+    using ProportionalControllerSE3d = ProportionalController<manif::SE3d>;
 }
 
 #endif

--- a/include/LieGroupControllers/ProportionalDerivativeController.h
+++ b/include/LieGroupControllers/ProportionalDerivativeController.h
@@ -1,0 +1,19 @@
+/**
+ * @file ProportionalDerivativeController.h
+ * @authors Giulio Romualdi
+ * @copyright This software may be modified and  distributed under the terms of
+ * the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef LIE_GROUP_CONTROLLERS_PROPORTIONAL_DERIVATIVE_CONTROLLER_H
+#define LIE_GROUP_CONTROLLERS_PROPORTIONAL__DERIVATIVE_CONTROLLER_H
+
+#include <LieGroupControllers/impl/ProportionalDerivativeController/Controller.h>
+
+namespace LieGroupControllers
+{
+    using ProportionalDerivativeControllerSO3 = ProportionalDerivativeController<manif::SO3d>;
+    using ProportionalDerivativeControllerSE3 = ProportionalDerivativeController<manif::SE3d>;
+}
+
+#endif

--- a/include/LieGroupControllers/ProportionalDerivativeController.h
+++ b/include/LieGroupControllers/ProportionalDerivativeController.h
@@ -12,8 +12,8 @@
 
 namespace LieGroupControllers
 {
-    using ProportionalDerivativeControllerSO3 = ProportionalDerivativeController<manif::SO3d>;
-    using ProportionalDerivativeControllerSE3 = ProportionalDerivativeController<manif::SE3d>;
+    using ProportionalDerivativeControllerSO3d = ProportionalDerivativeController<manif::SO3d>;
+    using ProportionalDerivativeControllerSE3d = ProportionalDerivativeController<manif::SE3d>;
 }
 
 #endif

--- a/include/LieGroupControllers/impl/ControllerBase.h
+++ b/include/LieGroupControllers/impl/ControllerBase.h
@@ -1,0 +1,86 @@
+/**
+ * @file ControllerBase.h
+ * @authors Giulio Romualdi
+ * @copyright This software may be modified and  distributed under the terms of
+ * the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef LIE_GROUP_CONTROLLERS_IMPL_CONTROLLER_BASE_H
+#define LIE_GROUP_CONTROLLERS_IMPL_CONTROLLER_BASE_H
+
+#include <LieGroupControllers/impl/traits.h>
+
+namespace LieGroupControllers
+{
+
+template <class _Derived> class ControllerBase
+{
+public:
+
+    using State = typename internal::traits<_Derived>::State;
+    using Vector = typename internal::traits<_Derived>::Vector;
+    using Gains = typename internal::traits<_Derived>::Gains;
+
+private:
+    _Derived& derived()
+    {
+        return *static_cast<_Derived*>(this);
+    }
+    const _Derived& derived() const
+    {
+        return *static_cast<const _Derived*>(this);
+    }
+
+public:
+    bool setState(const State& state);
+
+    bool setDesiredState(const State& state);
+
+    bool setFeedForward(const Vector& feedForward);
+
+    void setGains(const Gains& gains);
+
+    void computeControlLaw();
+
+    const Vector& getControl() const;
+};
+
+template <class _Derived>
+bool ControllerBase<_Derived>::setState(const ControllerBase<_Derived>::State& state)
+{
+    return this->derived().setState(state);
+}
+
+template <class _Derived>
+bool ControllerBase<_Derived>::setDesiredState(const ControllerBase<_Derived>::State& state)
+{
+    return this->derived().setDesiredState(state);
+}
+
+template <class _Derived>
+bool ControllerBase<_Derived>::setFeedForward(const ControllerBase<_Derived>::Vector& feedForward)
+{
+    return this->derived().setFeedForward(feedForward);
+}
+
+template <class _Derived> void ControllerBase<_Derived>::setGains(const Gains& gains)
+{
+    this->derived().setGains(gains);
+    return;
+}
+
+template <class _Derived> void ControllerBase<_Derived>::computeControlLaw()
+{
+    this->derived().computeControlLaw();
+    return;
+}
+
+template <class _Derived>
+const typename ControllerBase<_Derived>::Vector& ControllerBase<_Derived>::getControl() const
+{
+    return this->derived().getControl();
+}
+
+} // namespace LieGroupControllers
+
+#endif // LIE_GROUP_CONTROLLERS_IMPL_CONTROLLER_BASE_H

--- a/include/LieGroupControllers/impl/ControllerBase.h
+++ b/include/LieGroupControllers/impl/ControllerBase.h
@@ -13,13 +13,19 @@
 namespace LieGroupControllers
 {
 
+/**
+ * ControllerBase describes a base controller
+ * @tparam _Derived type of the Derived class. Necessary to implement the Curiously recurring
+ * template pattern.
+ */
 template <class _Derived> class ControllerBase
 {
 public:
-
-    using State = typename internal::traits<_Derived>::State;
-    using Vector = typename internal::traits<_Derived>::Vector;
-    using Gains = typename internal::traits<_Derived>::Gains;
+    using State = typename internal::traits<_Derived>::State; /**< State type */
+    using Vector = typename internal::traits<_Derived>::Vector; /**< Here we consider a Vector an
+                                                                   element of the tangent space of
+                                                                   the Group. */
+    using Gains = typename internal::traits<_Derived>::Gains; /**< Gains used by the controller */
 
 private:
     _Derived& derived()
@@ -32,16 +38,46 @@ private:
     }
 
 public:
+    /**
+     * Set the control state.
+     * @param state of the system.
+     * @return true in case of success, false otherwise.
+     */
     bool setState(const State& state);
 
+    /**
+     * Set the desired state.
+     * @param state of the system.
+     * @return true in case of success, false otherwise.
+     */
     bool setDesiredState(const State& state);
 
+    /**
+     * Set the feedforward term of the controller.
+     * @param feedforward is a vector of the tangent space of the the group.
+     * @return true in case of success, false otherwise.
+     */
     bool setFeedForward(const Vector& feedForward);
 
+    /**
+     * Set the controller gains.
+     * @param gains contains the controller gains.
+     */
     void setGains(const Gains& gains);
 
+    /**
+     * Evaluate the control law.
+     */
     void computeControlLaw();
 
+    /**
+     * Get the control signal.
+     * @return a vector containing the control effort.
+     * @note Please call this function only after computeControlLaw().
+     * @note In the current implementation the control effort belongs to the langet space at the
+     * identity, $\fT_\eps \mathcal{M}$\f. Please use the Adjoint transformation to convert the
+     * express the vector in a different tangent space.
+     */
     const Vector& getControl() const;
 };
 

--- a/include/LieGroupControllers/impl/ControllerBase.h
+++ b/include/LieGroupControllers/impl/ControllerBase.h
@@ -23,7 +23,7 @@ template <class _Derived> class ControllerBase
 public:
     using State = typename internal::traits<_Derived>::State; /**< State type */
     using Vector = typename internal::traits<_Derived>::Vector; /**< Here we consider a Vector an
-                                                                   element of the tangent space of
+                                                                   element of the lie algebra of
                                                                    the Group. */
     using Gains = typename internal::traits<_Derived>::Gains; /**< Gains used by the controller */
 

--- a/include/LieGroupControllers/impl/ControllerBase.h
+++ b/include/LieGroupControllers/impl/ControllerBase.h
@@ -26,6 +26,7 @@ public:
                                                                    element of the lie algebra of
                                                                    the Group. */
     using Gains = typename internal::traits<_Derived>::Gains; /**< Gains used by the controller */
+    using LieGroup = typename internal::traits<_Derived>::LieGroup; /**< Lie Group */
 
 private:
     _Derived& derived()

--- a/include/LieGroupControllers/impl/ControllerBase.h
+++ b/include/LieGroupControllers/impl/ControllerBase.h
@@ -74,7 +74,7 @@ public:
      * Get the control signal.
      * @return a vector containing the control effort.
      * @note Please call this function only after computeControlLaw().
-     * @note In the current implementation the control effort belongs to the langet space at the
+     * @note In the current implementation the control effort belongs to the tangent space at the
      * identity, $\fT_\eps \mathcal{M}$\f. Please use the Adjoint transformation to convert the
      * express the vector in a different tangent space.
      */

--- a/include/LieGroupControllers/impl/ProportionalController/Controller.h
+++ b/include/LieGroupControllers/impl/ProportionalController/Controller.h
@@ -1,16 +1,16 @@
 /**
- * @file ProportionalController.h
+ * @file Controller.h
  * @authors Giulio Romualdi
  * @copyright This software may be modified and  distributed under the terms of
  * the GNU Lesser General Public License v2.1 or any later version.
  */
 
-#ifndef LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_CONTROLLER_H
-#define LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_CONTROLLER_H
+#ifndef LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_CONTROLLER_CONTROLLER_H
+#define LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_CONTROLLER_CONTROLLER_H
 
 #include <type_traits>
 
-#include <LieGroupControllers/impl/ProportionalController/ProportionalController_base.h>
+#include <LieGroupControllers/impl/ProportionalController/ControllerBase.h>
 #include <manif/manif.h>
 
 namespace LieGroupControllers
@@ -47,4 +47,4 @@ class ProportionalController
 
 } // namespace LieGroupControllers
 
-#endif // LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_CONTROLLER_H
+#endif // LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_CONTROLLER_CONTROLLER_H

--- a/include/LieGroupControllers/impl/ProportionalController/Controller.h
+++ b/include/LieGroupControllers/impl/ProportionalController/Controller.h
@@ -37,12 +37,17 @@ template <typename _LieGroupType> struct traits<ProportionalController<_LieGroup
 namespace LieGroupControllers
 {
 
+/**
+ * ProporionalDerivativeController describes a PD controller on Lie Groups.
+ * @tparam _LieGroupType describes the Lie Group.
+ * @note _LieGroupType must derived from manif::LieGroupBase<_LieGroupType>
+ */
 template <typename _LieGroupType>
 class ProportionalController
     : public ProportionalControllerBase<ProportionalController<_LieGroupType>>
 {
     static_assert(std::is_base_of<manif::LieGroupBase<_LieGroupType>, _LieGroupType>::value,
-                  "The type must derive from manif");
+                  "The template type must derive from 'manif::LieGroupBase<>'");
 };
 
 } // namespace LieGroupControllers

--- a/include/LieGroupControllers/impl/ProportionalController/ControllerBase.h
+++ b/include/LieGroupControllers/impl/ProportionalController/ControllerBase.h
@@ -1,12 +1,12 @@
 /**
- * @file ProportionalControllerBase.h
+ * @file ControllerBase.h
  * @authors Giulio Romualdi
  * @copyright This software may be modified and  distributed under the terms of
  * the GNU Lesser General Public License v2.1 or any later version.
  */
 
-#ifndef LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_CONTROLLER_BASE_H
-#define LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_CONTROLLER_BASE_H
+#ifndef LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_CONTROLLER_CONTROLLER_BASE_H
+#define LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_CONTROLLER_CONTROLLER_BASE_H
 
 #include <LieGroupControllers/impl/ControllerBase.h>
 #include <tuple>
@@ -84,4 +84,4 @@ ProportionalControllerBase<_Derived>::getControl() const
 
 } // namespace LieGroupControllers
 
-#endif //LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_CONTROLLER_H
+#endif // LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_CONTROLLER_CONTROLLER_BASE_H

--- a/include/LieGroupControllers/impl/ProportionalController/ControllerBase.h
+++ b/include/LieGroupControllers/impl/ProportionalController/ControllerBase.h
@@ -16,13 +16,10 @@ namespace LieGroupControllers
 template <typename _Derived>
 class ProportionalControllerBase : public ControllerBase<_Derived>
 {
-
-public:
     using State = typename ControllerBase<_Derived>::State;
     using Vector = typename ControllerBase<_Derived>::Vector;
     using Gains = typename ControllerBase<_Derived>::Gains;
 
-private:
     State m_state;
     State m_desiredState;
     Vector m_feedForward;

--- a/include/LieGroupControllers/impl/ProportionalController/ControllerBase.h
+++ b/include/LieGroupControllers/impl/ProportionalController/ControllerBase.h
@@ -19,11 +19,11 @@ template <typename _Derived> class ProportionalControllerBase : public Controlle
     using Vector = typename ControllerBase<_Derived>::Vector;
     using Gains = typename ControllerBase<_Derived>::Gains;
 
-    State m_state;
-    State m_desiredState;
-    Vector m_feedForward;
-    Vector m_controlOutput;
-    Gains m_gain;
+    State m_state{State::Identity()};
+    State m_desiredState{State::Identity()};
+    Vector m_feedForward{Vector::Zero()};
+    Vector m_controlOutput{Vector::Zero()};
+    Gains m_gain{0};
 
 public:
     /**

--- a/include/LieGroupControllers/impl/ProportionalController/ControllerBase.h
+++ b/include/LieGroupControllers/impl/ProportionalController/ControllerBase.h
@@ -104,7 +104,7 @@ template <typename _Derived> void ProportionalControllerBase<_Derived>::computeC
     // Indeed here log() is a sequence of an actual logarithm mapping of the group plus a vee
     // operator.
     auto error = (m_desiredState.compose(m_state.inverse())).log();
-    m_controlOutput = m_feedForward.coeffs() + m_gain * error.coeffs();
+    m_controlOutput = m_feedForward + error * m_gain;
 }
 
 template <typename _Derived>

--- a/include/LieGroupControllers/impl/ProportionalController/ControllerBase.h
+++ b/include/LieGroupControllers/impl/ProportionalController/ControllerBase.h
@@ -65,7 +65,7 @@ public:
      * Get the control signal.
      * @return a vector containing the control effort.
      * @note Please call this function only after computeControlLaw().
-     * @note In the current implementation the control effort belongs to the langet space at the
+     * @note In the current implementation the control effort belongs to the tangent space at the
      * identity, $\fT_\eps \mathcal{M}$\f. Please use the Adjoint transformation to convert the
      * express the vector in a different tangent space.
      */

--- a/include/LieGroupControllers/impl/ProportionalController/ProportionalController.h
+++ b/include/LieGroupControllers/impl/ProportionalController/ProportionalController.h
@@ -1,0 +1,50 @@
+/**
+ * @file ProportionalController.h
+ * @authors Giulio Romualdi
+ * @copyright This software may be modified and  distributed under the terms of
+ * the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_CONTROLLER_H
+#define LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_CONTROLLER_H
+
+#include <type_traits>
+
+#include <LieGroupControllers/impl/ProportionalController/ProportionalController_base.h>
+#include <manif/manif.h>
+
+namespace LieGroupControllers
+{
+
+// Forward declare for type traits specialization
+template <typename _LieGroupType> class ProportionalController;
+
+namespace internal
+{
+
+template <typename _LieGroupType> struct traits<ProportionalController<_LieGroupType>>
+{
+    using LieGroup = typename manif::LieGroupBase<_LieGroupType>::LieGroup;
+    using Tangent = typename manif::LieGroupBase<_LieGroupType>::Tangent;
+    using State = LieGroup;
+    using Vector = Tangent;
+    using Gains = double;
+};
+
+} // namespace internal
+} // namespace LieGroupControllers
+
+namespace LieGroupControllers
+{
+
+template <typename _LieGroupType>
+class ProportionalController
+    : public ProportionalControllerBase<ProportionalController<_LieGroupType>>
+{
+    static_assert(std::is_base_of<manif::LieGroupBase<_LieGroupType>, _LieGroupType>::value,
+                  "The type must derive from manif");
+};
+
+} // namespace LieGroupControllers
+
+#endif // LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_CONTROLLER_H

--- a/include/LieGroupControllers/impl/ProportionalController/ProportionalController_base.h
+++ b/include/LieGroupControllers/impl/ProportionalController/ProportionalController_base.h
@@ -1,0 +1,87 @@
+/**
+ * @file ProportionalControllerBase.h
+ * @authors Giulio Romualdi
+ * @copyright This software may be modified and  distributed under the terms of
+ * the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_CONTROLLER_BASE_H
+#define LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_CONTROLLER_BASE_H
+
+#include <LieGroupControllers/impl/ControllerBase.h>
+#include <tuple>
+
+namespace LieGroupControllers
+{
+template <typename _Derived>
+class ProportionalControllerBase : public ControllerBase<_Derived>
+{
+
+public:
+    using State = typename ControllerBase<_Derived>::State;
+    using Vector = typename ControllerBase<_Derived>::Vector;
+    using Gains = typename ControllerBase<_Derived>::Gains;
+
+private:
+    State m_state;
+    State m_desiredState;
+    Vector m_feedForward;
+    Vector m_controlOutput;
+    Gains m_gain;
+
+public:
+    bool setState(const State& state);
+
+    bool setDesiredState(const State& state);
+
+    bool setFeedForward(const Vector& feedForward);
+
+    void computeControlLaw();
+
+    void setGain(const Gains& gain);
+
+    const Vector& getControl() const;
+};
+
+template <typename _Derived> bool ProportionalControllerBase<_Derived>::setState(const State& state)
+{
+    m_state = state;
+    return true;
+}
+
+template <typename _Derived>
+bool ProportionalControllerBase<_Derived>::setDesiredState(const State& state)
+{
+    m_desiredState = state;
+    return true;
+}
+
+template <typename _Derived>
+bool ProportionalControllerBase<_Derived>::setFeedForward(const Vector& feedForward)
+{
+    m_feedForward = feedForward;
+    return true;
+}
+
+template <typename _Derived>
+void ProportionalControllerBase<_Derived>::setGain(const Gains& gain)
+{
+    m_gain = gain;
+}
+
+template <typename _Derived> void ProportionalControllerBase<_Derived>::computeControlLaw()
+{
+    auto error = (m_desiredState.compose(m_state.inverse())).log();
+    m_controlOutput = m_feedForward.coeffs() + m_gain * error.coeffs();
+}
+
+template <typename _Derived>
+const typename ProportionalControllerBase<_Derived>::Vector&
+ProportionalControllerBase<_Derived>::getControl() const
+{
+    return m_controlOutput;
+}
+
+} // namespace LieGroupControllers
+
+#endif //LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_CONTROLLER_H

--- a/include/LieGroupControllers/impl/ProportionalDerivativeController/Controller.h
+++ b/include/LieGroupControllers/impl/ProportionalDerivativeController/Controller.h
@@ -1,0 +1,50 @@
+/**
+ * @file Controller.h
+ * @authors Giulio Romualdi
+ * @copyright This software may be modified and  distributed under the terms of
+ * the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_DERIVATIVE_CONTROLLER_CONTROLLER_H
+#define LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_DERIVATIVE_CONTROLLER_CONTROLLER_H
+
+#include <type_traits>
+
+#include <LieGroupControllers/impl/ProportionalDerivativeController/ControllerBase.h>
+#include <manif/manif.h>
+
+namespace LieGroupControllers
+{
+
+// Forward declare for type traits specialization
+template <typename _LieGroupType> class ProportionalDerivativeController;
+
+namespace internal
+{
+
+template <typename _LieGroupType> struct traits<ProportionalDerivativeController<_LieGroupType>>
+{
+    using LieGroup = typename manif::LieGroupBase<_LieGroupType>::LieGroup;
+    using Tangent = typename manif::LieGroupBase<_LieGroupType>::Tangent;
+    using State = std::tuple<LieGroup, Tangent>;
+    using Vector = Tangent;
+    using Gains = std::tuple<double, double>;
+};
+
+} // namespace internal
+} // namespace LieGroupControllers
+
+namespace LieGroupControllers
+{
+
+template <typename _LieGroupType>
+class ProportionalDerivativeController
+    : public ProportionalDerivativeControllerBase<ProportionalDerivativeController<_LieGroupType>>
+{
+    static_assert(std::is_base_of<manif::LieGroupBase<_LieGroupType>, _LieGroupType>::value,
+                  "The type must derive from manif");
+};
+
+} // namespace LieGroupControllers
+
+#endif // LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_DERIVATIVE_CONTROLLER_CONTROLLER_H

--- a/include/LieGroupControllers/impl/ProportionalDerivativeController/Controller.h
+++ b/include/LieGroupControllers/impl/ProportionalDerivativeController/Controller.h
@@ -10,8 +10,9 @@
 
 #include <type_traits>
 
-#include <LieGroupControllers/impl/ProportionalDerivativeController/ControllerBase.h>
 #include <manif/manif.h>
+
+#include <LieGroupControllers/impl/ProportionalDerivativeController/ControllerBase.h>
 
 namespace LieGroupControllers
 {
@@ -37,12 +38,17 @@ template <typename _LieGroupType> struct traits<ProportionalDerivativeController
 namespace LieGroupControllers
 {
 
+/**
+ * ProporionalDerivativeController describes a PD controller on Lie Groups.
+ * @tparam _LieGroupType describes the Lie Group.
+ * @note _LieGroupType must derived from manif::LieGroupBase<_LieGroupType>
+ */
 template <typename _LieGroupType>
 class ProportionalDerivativeController
     : public ProportionalDerivativeControllerBase<ProportionalDerivativeController<_LieGroupType>>
 {
     static_assert(std::is_base_of<manif::LieGroupBase<_LieGroupType>, _LieGroupType>::value,
-                  "The type must derive from manif");
+                  "The template type must derive from 'manif::LieGroupBase<>'");
 };
 
 } // namespace LieGroupControllers

--- a/include/LieGroupControllers/impl/ProportionalDerivativeController/ControllerBase.h
+++ b/include/LieGroupControllers/impl/ProportionalDerivativeController/ControllerBase.h
@@ -16,13 +16,10 @@ namespace LieGroupControllers
 template <typename _Derived>
 class ProportionalDerivativeControllerBase : public ControllerBase<_Derived>
 {
-
-public:
     using State = typename ControllerBase<_Derived>::State;
     using Vector = typename ControllerBase<_Derived>::Vector;
     using Gains = typename ControllerBase<_Derived>::Gains;
 
-private:
     State m_state;
     State m_desiredState;
     Vector m_feedForward;

--- a/include/LieGroupControllers/impl/ProportionalDerivativeController/ControllerBase.h
+++ b/include/LieGroupControllers/impl/ProportionalDerivativeController/ControllerBase.h
@@ -1,0 +1,102 @@
+/**
+ * @file ControllerBase.h
+ * @authors Giulio Romualdi
+ * @copyright This software may be modified and  distributed under the terms of
+ * the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_DERIVATIVE_CONTROLLER_CONTROLLER_BASE_H
+#define LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_DERIVATIVE_CONTROLLER_CONTROLLER_BASE_H
+
+#include <LieGroupControllers/impl/ControllerBase.h>
+#include <tuple>
+
+namespace LieGroupControllers
+{
+template <typename _Derived>
+class ProportionalDerivativeControllerBase : public ControllerBase<_Derived>
+{
+
+public:
+    using State = typename ControllerBase<_Derived>::State;
+    using Vector = typename ControllerBase<_Derived>::Vector;
+    using Gains = typename ControllerBase<_Derived>::Gains;
+
+private:
+    State m_state;
+    State m_desiredState;
+    Vector m_feedForward;
+    Vector m_controlOutput;
+    Gains m_gain;
+
+public:
+    bool setState(const State& state);
+
+    bool setDesiredState(const State& state);
+
+    bool setFeedForward(const Vector& feedForward);
+
+    void computeControlLaw();
+
+    void setGain(const Gains& gain);
+
+    const Vector& getControl() const;
+};
+
+template <typename _Derived>
+bool ProportionalDerivativeControllerBase<_Derived>::setState(const State& state)
+{
+    m_state = state;
+    return true;
+}
+
+template <typename _Derived>
+bool ProportionalDerivativeControllerBase<_Derived>::setDesiredState(const State& state)
+{
+    m_desiredState = state;
+    return true;
+}
+
+template <typename _Derived>
+bool ProportionalDerivativeControllerBase<_Derived>::setFeedForward(const Vector& feedForward)
+{
+    m_feedForward = feedForward;
+    return true;
+}
+
+template <typename _Derived>
+void ProportionalDerivativeControllerBase<_Derived>::setGain(const Gains& gain)
+{
+    m_gain = gain;
+}
+
+template <typename _Derived>
+void ProportionalDerivativeControllerBase<_Derived>::computeControlLaw()
+{
+    const auto& kp = std::get<0>(m_gain);
+    const auto& kd = std::get<1>(m_gain);
+
+    const auto& state = std::get<0>(m_state);
+    const auto& stateDerivative = std::get<1>(m_state);
+
+    const auto& desiredState = std::get<0>(m_desiredState);
+    const auto& desiredStateDerivative = std::get<1>(m_desiredState);
+
+    // evaluate state
+    auto errorState = (desiredState.compose(state.inverse())).log();
+    auto errorStateDerivative = desiredStateDerivative - stateDerivative;
+
+    m_controlOutput
+        = m_feedForward.coeffs() + kd * errorStateDerivative.coeffs() + kp * errorState.coeffs();
+}
+
+template <typename _Derived>
+const typename ProportionalDerivativeControllerBase<_Derived>::Vector&
+ProportionalDerivativeControllerBase<_Derived>::getControl() const
+{
+    return m_controlOutput;
+}
+
+} // namespace LieGroupControllers
+
+#endif // LIE_GROUP_CONTROLLERS_IMPL_PROPORTIONAL_DERIVATIVE_CONTROLLER_CONTROLLER_BASE_H

--- a/include/LieGroupControllers/impl/ProportionalDerivativeController/ControllerBase.h
+++ b/include/LieGroupControllers/impl/ProportionalDerivativeController/ControllerBase.h
@@ -68,7 +68,7 @@ public:
      * Get the control signal.
      * @return a vector containing the control effort.
      * @note Please call this function only after computeControlLaw().
-     * @note In the current implementation the control effort belongs to the langet space at the
+     * @note In the current implementation the control effort belongs to the tangent space at the
      * identity, $\fT_\eps \mathcal{M}$\f. Please use the Adjoint transformation to convert the
      * express the vector in a different tangent space.
      */

--- a/include/LieGroupControllers/impl/ProportionalDerivativeController/ControllerBase.h
+++ b/include/LieGroupControllers/impl/ProportionalDerivativeController/ControllerBase.h
@@ -19,12 +19,13 @@ class ProportionalDerivativeControllerBase : public ControllerBase<_Derived>
     using State = typename ControllerBase<_Derived>::State;
     using Vector = typename ControllerBase<_Derived>::Vector;
     using Gains = typename ControllerBase<_Derived>::Gains;
+    using LieGroup = typename ControllerBase<_Derived>::LieGroup;
 
-    State m_state;
-    State m_desiredState;
-    Vector m_feedForward;
-    Vector m_controlOutput;
-    Gains m_gain;
+    State m_state{LieGroup::Identity(), Vector::Zero()};
+    State m_desiredState{LieGroup::Identity(), Vector::Zero()};
+    Vector m_feedForward{Vector::Zero()};
+    Vector m_controlOutput{Vector::Zero()};
+    Gains m_gain{0, 0};
 
 public:
     /**

--- a/include/LieGroupControllers/impl/ProportionalDerivativeController/ControllerBase.h
+++ b/include/LieGroupControllers/impl/ProportionalDerivativeController/ControllerBase.h
@@ -27,16 +27,51 @@ class ProportionalDerivativeControllerBase : public ControllerBase<_Derived>
     Gains m_gain;
 
 public:
+    /**
+     * Set the control state.
+     * @param state of the system.
+     * @note for the ProportionalDerivativeController the state is given by the element of the Lie
+     * group and one of it's tangent space at the identity.
+     * @return true in case of success, false otherwise.
+     */
     bool setState(const State& state);
 
+    /**
+     * Set the desired state.
+     * @param state of the system.
+     * @note for the ProportionalDerivativeController the state is given by the element of the Lie
+     * group and one of it's tangent space at the identity.
+     * @return true in case of success, false otherwise.
+     */
     bool setDesiredState(const State& state);
 
+    /**
+     * Set the feedforward term of the controller.
+     * @param feedforward is a vector of the tangent space of the the group.
+     * @return true in case of success, false otherwise.
+     */
     bool setFeedForward(const Vector& feedForward);
 
+    /**
+     * Set the controller gains.
+     * @param gains contains the controller gains.
+     * @note for the ProportionalController the gain is simply a double.
+     */
+    void setGains(const Gains& gains);
+
+    /**
+     * Evaluate the control law.
+     */
     void computeControlLaw();
 
-    void setGain(const Gains& gain);
-
+    /**
+     * Get the control signal.
+     * @return a vector containing the control effort.
+     * @note Please call this function only after computeControlLaw().
+     * @note In the current implementation the control effort belongs to the langet space at the
+     * identity, $\fT_\eps \mathcal{M}$\f. Please use the Adjoint transformation to convert the
+     * express the vector in a different tangent space.
+     */
     const Vector& getControl() const;
 };
 
@@ -62,7 +97,7 @@ bool ProportionalDerivativeControllerBase<_Derived>::setFeedForward(const Vector
 }
 
 template <typename _Derived>
-void ProportionalDerivativeControllerBase<_Derived>::setGain(const Gains& gain)
+void ProportionalDerivativeControllerBase<_Derived>::setGains(const Gains& gain)
 {
     m_gain = gain;
 }
@@ -70,8 +105,8 @@ void ProportionalDerivativeControllerBase<_Derived>::setGain(const Gains& gain)
 template <typename _Derived>
 void ProportionalDerivativeControllerBase<_Derived>::computeControlLaw()
 {
-    const auto& kp = std::get<0>(m_gain);
-    const auto& kd = std::get<1>(m_gain);
+    const double& kp = std::get<0>(m_gain);
+    const double& kd = std::get<1>(m_gain);
 
     const auto& state = std::get<0>(m_state);
     const auto& stateDerivative = std::get<1>(m_state);
@@ -80,11 +115,11 @@ void ProportionalDerivativeControllerBase<_Derived>::computeControlLaw()
     const auto& desiredStateDerivative = std::get<1>(m_desiredState);
 
     // evaluate state
-    auto errorState = (desiredState.compose(state.inverse())).log();
-    auto errorStateDerivative = desiredStateDerivative - stateDerivative;
+    Vector errorState = (desiredState.compose(state.inverse())).log();
+    Vector errorStateDerivative = desiredStateDerivative - stateDerivative;
 
-    m_controlOutput
-        = m_feedForward.coeffs() + kd * errorStateDerivative.coeffs() + kp * errorState.coeffs();
+    // compute the control law
+    m_controlOutput = m_feedForward + errorStateDerivative * kd + errorState * kp;
 }
 
 template <typename _Derived>

--- a/include/LieGroupControllers/impl/traits.h
+++ b/include/LieGroupControllers/impl/traits.h
@@ -1,0 +1,32 @@
+/**
+ * @file traits.h
+ * @authors Giulio Romualdi
+ * @copyright This software may be modified and  distributed under the terms of
+ * the GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef LIE_GROUP_CONTROLLERS_IMPL_TRAITS_H
+#define LIE_GROUP_CONTROLLERS_IMPL_TRAITS_H
+
+namespace LieGroupControllers
+{
+namespace internal
+{
+
+template <typename T> struct traits;
+
+/// @note the following is from the Eigen library
+/// here we say once and for all that traits<const T> == traits<T>
+///
+/// When constness must affect traits, it has to be constness on
+/// template parameters on which T itself depends.
+/// For example, traits<Map<const T> > != traits<Map<T> >, but
+///              traits<const Map<T> > == traits<Map<T> >
+template <typename T> struct traits<const T> : traits<T>
+{
+};
+
+} // namespace internal
+} // namespace LieGroupControllers
+
+#endif // LIE_GROUP_CONTROLLERS_IMPL_TRAITS_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,3 +5,8 @@ add_liegroupcontrollers_test(
   NAME ProportionalController
   SOURCES ProportionalControllerTest.cpp
   LINKS LieGroupControllers::LieGroupControllers)
+
+add_liegroupcontrollers_test(
+  NAME ProportionalDerivativeController
+  SOURCES ProportionalDerivativeControllerTest.cpp
+  LINKS LieGroupControllers::LieGroupControllers)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Authors: Giulio Romualdi
+# CopyPolicy: Released under the terms of the LGPLv2.1 or later
+
+add_liegroupcontrollers_test(
+  NAME ProportionalController
+  SOURCES ProportionalControllerTest.cpp
+  LINKS LieGroupControllers::LieGroupControllers)

--- a/tests/ProportionalControllerTest.cpp
+++ b/tests/ProportionalControllerTest.cpp
@@ -1,0 +1,76 @@
+/**
+ * @file ProportionalControllerTest.cpp
+ * @author Giulio Romualdi
+ * @copyright Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ * @date 2020
+ */
+
+// Catch2
+#include <catch2/catch.hpp>
+
+#include <LieGroupControllers/ProportionalController.h>
+using namespace LieGroupControllers;
+
+TEST_CASE("Proportional Controller [SO(3)]")
+{
+    manif::SO3d desiredState, state;
+    desiredState.setRandom();
+    state.setRandom();
+
+    constexpr double dT = 0.01;
+    constexpr double kp = 10;
+    constexpr std::size_t numberOfIteration = 1e3;
+
+    ProportinalControllerSO3 controller;
+    controller.setGain(kp);
+    controller.setDesiredState(desiredState);
+
+    auto feedForward = Eigen::Vector3d::Zero();
+    controller.setFeedForward(feedForward);
+
+    for (std::size_t i = 0; i < numberOfIteration; i++)
+    {
+        controller.setState(state);
+        controller.computeControlLaw();
+        auto controlOutput = controller.getControl();
+        decltype(controlOutput) controlOutputDT = controlOutput.coeffs() * dT;
+        state = controlOutputDT + state;
+    }
+
+    // check the error
+    auto error = state.compose(desiredState.inverse()).log();
+    REQUIRE(error.coeffs().norm() < 1e-4);
+}
+
+TEST_CASE("Proportional Controller [SE(3)]")
+{
+    manif::SE3d desiredState, state;
+    desiredState.setRandom();
+    state.setRandom();
+
+    constexpr double dT = 0.01;
+    constexpr double kp = 10;
+    constexpr std::size_t numberOfIteration = 1e3;
+
+    ProportinalControllerSE3 controller;
+    controller.setGain(kp);
+    controller.setDesiredState(desiredState);
+
+    auto feedForward = Eigen::Matrix<double, 6, 1>::Zero();
+    controller.setFeedForward(feedForward);
+
+    for (std::size_t i = 0; i < numberOfIteration; i++)
+    {
+        controller.setState(state);
+        controller.computeControlLaw();
+        auto controlOutput = controller.getControl();
+        decltype(controlOutput) controlOutputDT = controlOutput.coeffs() * dT;
+
+        // propagate the dynamics
+        state = controlOutputDT + state;
+    }
+
+    // check the error
+    auto error = state.compose(desiredState.inverse()).log();
+    REQUIRE(error.coeffs().norm() < 1e-4);
+}

--- a/tests/ProportionalControllerTest.cpp
+++ b/tests/ProportionalControllerTest.cpp
@@ -21,7 +21,7 @@ TEST_CASE("Proportional Controller [SO(3)]")
     constexpr double kp = 10;
     constexpr std::size_t numberOfIteration = 1e3;
 
-    ProportinalControllerSO3 controller;
+    ProportionalControllerSO3 controller;
     controller.setGain(kp);
     controller.setDesiredState(desiredState);
 
@@ -52,7 +52,7 @@ TEST_CASE("Proportional Controller [SE(3)]")
     constexpr double kp = 10;
     constexpr std::size_t numberOfIteration = 1e3;
 
-    ProportinalControllerSE3 controller;
+    ProportionalControllerSE3 controller;
     controller.setGain(kp);
     controller.setDesiredState(desiredState);
 

--- a/tests/ProportionalControllerTest.cpp
+++ b/tests/ProportionalControllerTest.cpp
@@ -21,7 +21,7 @@ TEST_CASE("Proportional Controller [SO(3)]")
     constexpr double kp = 10;
     constexpr std::size_t numberOfIteration = 1e3;
 
-    ProportionalControllerSO3 controller;
+    ProportionalControllerSO3d controller;
     controller.setGain(kp);
     controller.setDesiredState(desiredState);
 
@@ -52,7 +52,7 @@ TEST_CASE("Proportional Controller [SE(3)]")
     constexpr double kp = 10;
     constexpr std::size_t numberOfIteration = 1e3;
 
-    ProportionalControllerSE3 controller;
+    ProportionalControllerSE3d controller;
     controller.setGain(kp);
     controller.setDesiredState(desiredState);
 

--- a/tests/ProportionalDerivativeControllerTest.cpp
+++ b/tests/ProportionalDerivativeControllerTest.cpp
@@ -1,0 +1,86 @@
+/**
+ * @file ProportionalDerivativeControllerTest.cpp
+ * @author Giulio Romualdi
+ * @copyright Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ * @date 2020
+ */
+
+// Catch2
+#include <catch2/catch.hpp>
+
+#include <LieGroupControllers/ProportionalDerivativeController.h>
+using namespace LieGroupControllers;
+
+TEST_CASE("Proportional Derivative Controller [SO(3)]")
+{
+    manif::SO3d desiredState, state;
+    desiredState.setRandom();
+    state.setRandom();
+    manif::SO3d::Tangent stateDerivative = Eigen::Vector3d::Zero();
+    const manif::SO3d::Tangent desiredStateDerivative = Eigen::Vector3d::Zero();
+    const auto feedForward = Eigen::Vector3d::Zero();
+
+    constexpr double dT = 0.01;
+    constexpr double kp = 10;
+    constexpr double kd = 2 * std::sqrt(kp);
+    constexpr std::size_t numberOfIteration = 1e3;
+
+    ProportionalDerivativeControllerSO3 controller;
+    controller.setGain({kp, kd});
+    controller.setDesiredState({desiredState, desiredStateDerivative});
+
+    controller.setFeedForward(feedForward);
+
+    for (std::size_t i = 0; i < numberOfIteration; i++)
+    {
+        controller.setState({state, stateDerivative});
+        controller.computeControlLaw();
+        auto controlOutput = controller.getControl();
+        manif::SO3d::Tangent stateDerivativeDT = stateDerivative.coeffs() * dT;
+        state = stateDerivativeDT + state;
+
+        manif::SO3d::Tangent controlOutputDT = controlOutput.coeffs() * dT;
+        stateDerivative += controlOutput * dT;
+    }
+
+    // check the error
+    auto error = state.compose(desiredState.inverse()).log();
+    REQUIRE(error.coeffs().norm() < 1e-4);
+}
+
+TEST_CASE("Proportional Derivative Controller [SE(3)]")
+{
+    manif::SE3d desiredState, state;
+    desiredState.setRandom();
+    state.setRandom();
+    manif::SE3d::Tangent stateDerivative = Eigen::Matrix<double, 6, 1>::Zero();
+    const manif::SE3d::Tangent desiredStateDerivative = Eigen::Matrix<double, 6, 1>::Zero();
+    const auto feedForward = Eigen::Matrix<double, 6, 1>::Zero();
+
+    constexpr double dT = 0.01;
+    constexpr double kp = 10;
+    constexpr double kd = 2 * std::sqrt(kp);
+    constexpr std::size_t numberOfIteration = 1e3;
+
+    ProportionalDerivativeControllerSE3 controller;
+    controller.setGain({kp, kd});
+    controller.setDesiredState({desiredState, desiredStateDerivative});
+
+    controller.setFeedForward(feedForward);
+
+    for (std::size_t i = 0; i < numberOfIteration; i++)
+    {
+        controller.setState({state, stateDerivative});
+        controller.computeControlLaw();
+        auto controlOutput = controller.getControl();
+        manif::SE3d::Tangent stateDerivativeDT = stateDerivative.coeffs() * dT;
+        state = stateDerivativeDT + state;
+
+        manif::SE3d::Tangent controlOutputDT = controlOutput.coeffs() * dT;
+        stateDerivative += controlOutput * dT;
+    }
+
+    // check the error
+    auto error = state.compose(desiredState.inverse()).log();
+    REQUIRE(error.coeffs().norm() < 1e-4);
+}

--- a/tests/ProportionalDerivativeControllerTest.cpp
+++ b/tests/ProportionalDerivativeControllerTest.cpp
@@ -8,6 +8,8 @@
 // Catch2
 #include <catch2/catch.hpp>
 
+#include <manif/manif.h>
+
 #include <LieGroupControllers/ProportionalDerivativeController.h>
 using namespace LieGroupControllers;
 
@@ -17,27 +19,39 @@ TEST_CASE("Proportional Derivative Controller [SO(3)]")
     desiredState.setRandom();
     state.setRandom();
     manif::SO3d::Tangent stateDerivative = Eigen::Vector3d::Zero();
+
     const manif::SO3d::Tangent desiredStateDerivative = Eigen::Vector3d::Zero();
     const auto feedForward = Eigen::Vector3d::Zero();
 
-    constexpr double dT = 0.01;
-    constexpr double kp = 10;
-    constexpr double kd = 2 * std::sqrt(kp);
-    constexpr std::size_t numberOfIteration = 1e3;
-
+    // Initialize the controller
     ProportionalDerivativeControllerSO3d controller;
-    controller.setGain({kp, kd});
+    constexpr double kp = 10;
+    const double kd = 2 * std::sqrt(kp);
+    controller.setGains({kp, kd});
     controller.setDesiredState({desiredState, desiredStateDerivative});
-
     controller.setFeedForward(feedForward);
 
+    // Test the controller
+    constexpr double dT = 0.01;
+    constexpr std::size_t numberOfIteration = 1e3;
     for (std::size_t i = 0; i < numberOfIteration; i++)
     {
         controller.setState({state, stateDerivative});
         controller.computeControlLaw();
         auto controlOutput = controller.getControl();
+
+        // Propagate the dynamics of the system.
+        // First of all we get the control output. In this particular case is the angular
+        // acceleration expressed in the inertial frame. Then the Manifold left plus operator is
+        // used state = stateDerivativeDT + state should be read as
+        // state_k+1 = exp(omega * dT) * state_k
         manif::SO3d::Tangent stateDerivativeDT = stateDerivative.coeffs() * dT;
         state = stateDerivativeDT + state;
+
+        // here the following operator has been used
+        // https://github.com/artivis/manif/blob/6d07bc65cc5b25c49f1231021be5e61132e5f777/include/manif/impl/tangent_base.h#L316-L318
+        // and
+        // https://github.com/artivis/manif/blob/6d07bc65cc5b25c49f1231021be5e61132e5f777/include/manif/impl/tangent_base.h#L300-L310
         stateDerivative += controlOutput * dT;
     }
 
@@ -52,27 +66,40 @@ TEST_CASE("Proportional Derivative Controller [SE(3)]")
     desiredState.setRandom();
     state.setRandom();
     manif::SE3d::Tangent stateDerivative = Eigen::Matrix<double, 6, 1>::Zero();
+
     const manif::SE3d::Tangent desiredStateDerivative = Eigen::Matrix<double, 6, 1>::Zero();
     const auto feedForward = Eigen::Matrix<double, 6, 1>::Zero();
 
-    constexpr double dT = 0.01;
-    constexpr double kp = 10;
-    constexpr double kd = 2 * std::sqrt(kp);
-    constexpr std::size_t numberOfIteration = 1e3;
-
+    // Initialize the controller
     ProportionalDerivativeControllerSE3d controller;
-    controller.setGain({kp, kd});
+    constexpr double kp = 10;
+    const double kd = 2 * std::sqrt(kp);
+    controller.setGains({kp, kd});
     controller.setDesiredState({desiredState, desiredStateDerivative});
 
     controller.setFeedForward(feedForward);
 
+    // Test the controller
+    constexpr double dT = 0.01;
+    constexpr std::size_t numberOfIteration = 1e3;
     for (std::size_t i = 0; i < numberOfIteration; i++)
     {
         controller.setState({state, stateDerivative});
         controller.computeControlLaw();
         auto controlOutput = controller.getControl();
+
+        // Propagate the dynamics of the system.
+        // First of all we get the control output. In this particular case is the angular
+        // acceleration expressed in the inertial frame. Then the Manifold left plus operator is
+        // used state = stateDerivativeDT + state should be read as
+        // state_k+1 = exp(v * dT) * state_k
         manif::SE3d::Tangent stateDerivativeDT = stateDerivative.coeffs() * dT;
         state = stateDerivativeDT + state;
+
+        // here the following operator has been used
+        // https://github.com/artivis/manif/blob/6d07bc65cc5b25c49f1231021be5e61132e5f777/include/manif/impl/tangent_base.h#L316-L318
+        // and
+        // https://github.com/artivis/manif/blob/6d07bc65cc5b25c49f1231021be5e61132e5f777/include/manif/impl/tangent_base.h#L300-L310
         stateDerivative += controlOutput * dT;
     }
 

--- a/tests/ProportionalDerivativeControllerTest.cpp
+++ b/tests/ProportionalDerivativeControllerTest.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Proportional Derivative Controller [SO(3)]")
     constexpr double kd = 2 * std::sqrt(kp);
     constexpr std::size_t numberOfIteration = 1e3;
 
-    ProportionalDerivativeControllerSO3 controller;
+    ProportionalDerivativeControllerSO3d controller;
     controller.setGain({kp, kd});
     controller.setDesiredState({desiredState, desiredStateDerivative});
 
@@ -38,8 +38,6 @@ TEST_CASE("Proportional Derivative Controller [SO(3)]")
         auto controlOutput = controller.getControl();
         manif::SO3d::Tangent stateDerivativeDT = stateDerivative.coeffs() * dT;
         state = stateDerivativeDT + state;
-
-        manif::SO3d::Tangent controlOutputDT = controlOutput.coeffs() * dT;
         stateDerivative += controlOutput * dT;
     }
 
@@ -62,7 +60,7 @@ TEST_CASE("Proportional Derivative Controller [SE(3)]")
     constexpr double kd = 2 * std::sqrt(kp);
     constexpr std::size_t numberOfIteration = 1e3;
 
-    ProportionalDerivativeControllerSE3 controller;
+    ProportionalDerivativeControllerSE3d controller;
     controller.setGain({kp, kd});
     controller.setDesiredState({desiredState, desiredStateDerivative});
 
@@ -75,8 +73,6 @@ TEST_CASE("Proportional Derivative Controller [SE(3)]")
         auto controlOutput = controller.getControl();
         manif::SE3d::Tangent stateDerivativeDT = stateDerivative.coeffs() * dT;
         state = stateDerivativeDT + state;
-
-        manif::SE3d::Tangent controlOutputDT = controlOutput.coeffs() * dT;
         stateDerivative += controlOutput * dT;
     }
 


### PR DESCRIPTION
This PR introduces the first version of the `lie-group-controllers`. The aim of the library is to contain same controllers designed in lie groups. 
The library depends only on `Eigen` and [`manif`](https://github.com/artivis/manif). 

All the controllers defined in `lie-group-controllers` have in common that they inherit from a templated base class ([CRTP](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern)). It allows one to write generic code abstracting the controller details. This follows the structure of `manif` and `Eigen`. 

The library implements two controllers:
1. Proportional Controller (`P controller`)
2. Proportional Derivative Controller (`PD controller`)

The controllers have the following form 

<p align="center">

|       Proportional Controller      | Proportional Derivative Controller |
|:-----------------------:|:-------------:|
| ![img-f6214bd2482f678b](https://user-images.githubusercontent.com/16744101/89174620-77c5b100-d586-11ea-88f7-318343c13b0f.png)  | ![img-40c85670ed9bec65](https://user-images.githubusercontent.com/16744101/89174628-7b593800-d586-11ea-8219-d3ea2cb70901.png)        |

</p>

where `X` and `Xᵈ` are elements of a Lie group. `∘` is the group operator. `ψ` represents an element in the Lie algebra of the Lie group whose coordinates are expressed in `ℝⁿ`. 

At the moment, the controllers support all the group defined in `manif`. Namely: 
- ℝ(n): Euclidean space with addition.
- SO(2): rotations in the plane.
- SE(2): rigid motion (rotation and translation) in the plane.
- SO(3): rotations in 3D space.
- SE(3): rigid motion (rotation and translation) in 3D space.


The library works fine on Linux and macOS. In windows, there are problems related to the compilation of `manif`. https://github.com/artivis/manif/pull/149 should fix the issue. 

cc @dic-iit/dynamic-interaction-control 