### PR TITLE
Add ProportionalControllerR3d and ProportionalDerivativeControllerR3d

### DIFF
--- a/include/LieGroupControllers/ProportionalController.h
+++ b/include/LieGroupControllers/ProportionalController.h
@@ -14,6 +14,7 @@ namespace LieGroupControllers
 {
     using ProportionalControllerSO3d = ProportionalController<manif::SO3d>;
     using ProportionalControllerSE3d = ProportionalController<manif::SE3d>;
+    using ProportionalControllerR3d = ProportionalController<manif::R3d>;
 }
 
 #endif

--- a/include/LieGroupControllers/ProportionalDerivativeController.h
+++ b/include/LieGroupControllers/ProportionalDerivativeController.h
@@ -14,6 +14,7 @@ namespace LieGroupControllers
 {
     using ProportionalDerivativeControllerSO3d = ProportionalDerivativeController<manif::SO3d>;
     using ProportionalDerivativeControllerSE3d = ProportionalDerivativeController<manif::SE3d>;
+    using ProportionalDerivativeControllerR3d = ProportionalDerivativeController<manif::R3d>;
 }
 
 #endif

--- a/tests/ProportionalControllerTest.cpp
+++ b/tests/ProportionalControllerTest.cpp
@@ -91,3 +91,43 @@ TEST_CASE("Proportional Controller [SE(3)]")
     auto error = state.compose(desiredState.inverse()).log();
     REQUIRE(error.coeffs().norm() < 1e-4);
 }
+
+TEST_CASE("Proportional Controller [R3]")
+{
+    manif::R3d desiredState, state;
+    desiredState.setRandom();
+    state.setRandom();
+
+    auto feedForward = Eigen::Vector3d::Zero();
+
+    // instantiate the controller
+    ProportionalControllerR3d controller;
+    constexpr double kp = 10;
+    controller.setGains(kp);
+    controller.setDesiredState(desiredState);
+    controller.setFeedForward(feedForward);
+
+    // Test the controller
+    constexpr double dT = 0.01;
+    constexpr std::size_t numberOfIteration = 1e3;
+    for (std::size_t i = 0; i < numberOfIteration; i++)
+    {
+        controller.setState(state);
+        controller.computeControlLaw();
+        auto controlOutput = controller.getControl();
+
+        // In this specific case the dynamics of the system is a simple integrator.
+        // and the controller is a simple P controller in R3.
+        // Let's check the last statement
+        Eigen::Vector3d expectedControlOutput = feedForward + kp * (desiredState.coeffs() - state.coeffs());
+        REQUIRE(expectedControlOutput.isApprox(controlOutput.coeffs()));
+
+        // Propagate the dynamics of the system.
+        manif::R3d::Tangent controlOutputDT = controlOutput.coeffs() * dT;
+        state = controlOutputDT + state;
+    }
+
+    // check the error
+    auto error = state.compose(desiredState.inverse()).log();
+    REQUIRE(error.coeffs().norm() < 1e-4);
+}

--- a/tests/ProportionalDerivativeControllerTest.cpp
+++ b/tests/ProportionalDerivativeControllerTest.cpp
@@ -107,3 +107,56 @@ TEST_CASE("Proportional Derivative Controller [SE(3)]")
     auto error = state.compose(desiredState.inverse()).log();
     REQUIRE(error.coeffs().norm() < 1e-4);
 }
+
+TEST_CASE("Proportional Derivative Controller [R3]")
+{
+    manif::R3d desiredState, state;
+    desiredState.setRandom();
+    state.setRandom();
+    manif::R3d::Tangent stateDerivative = Eigen::Vector3d::Zero();
+
+    const manif::R3d::Tangent desiredStateDerivative = Eigen::Vector3d::Zero();
+    const auto feedForward = Eigen::Vector3d::Zero();
+
+    // Initialize the controller
+    ProportionalDerivativeControllerR3d controller;
+    constexpr double kp = 10;
+    const double kd = 2 * std::sqrt(kp);
+    controller.setGains({kp, kd});
+    controller.setDesiredState({desiredState, desiredStateDerivative});
+    controller.setFeedForward(feedForward);
+
+    // Test the controller
+    constexpr double dT = 0.01;
+    constexpr std::size_t numberOfIteration = 1e3;
+    for (std::size_t i = 0; i < numberOfIteration; i++)
+    {
+        controller.setState({state, stateDerivative});
+        controller.computeControlLaw();
+        auto controlOutput = controller.getControl();
+
+        // In this specific case the dynamics of the system is a simple double integrator.
+        // and the controller is a simple PD controller in R3.
+        // Let's check the last statement
+
+        Eigen::Vector3d expectedControlOutput = feedForward
+                                                + kd * (desiredStateDerivative.coeffs() - stateDerivative.coeffs())
+                                                + kp * (desiredState.coeffs() - state.coeffs());
+
+        REQUIRE(expectedControlOutput.isApprox(controlOutput.coeffs()));
+
+        // Propagate the system dynamics
+        manif::R3d::Tangent stateDerivativeDT = stateDerivative.coeffs() * dT;
+        state = stateDerivativeDT + state;
+
+        // here the following operator has been used
+        // https://github.com/artivis/manif/blob/6d07bc65cc5b25c49f1231021be5e61132e5f777/include/manif/impl/tangent_base.h#L316-L318
+        // and
+        // https://github.com/artivis/manif/blob/6d07bc65cc5b25c49f1231021be5e61132e5f777/include/manif/impl/tangent_base.h#L300-L310
+        stateDerivative += controlOutput * dT;
+    }
+
+    // check the error
+    auto error = state.compose(desiredState.inverse()).log();
+    REQUIRE(error.coeffs().norm() < 1e-4);
+}


### PR DESCRIPTION
This PR introduces `ProportionalControllerR3d` and `ProportionalDerivativeControllerR3d` typedef. Furthermore, I developed two simple tests (one for each controller) to check that in this specific case the controllers are exactly equivalent to two simples `P` and `PD` controller in R3.
Namely, the P controller is exactly equivalent to 
```
u  = feed_forward + k_p * (x_desired - x_measured) 
```
while the PD controller
```
u  = feed_forward + k_p * (x_desired - x_measured) + k_d * (dx_desired - dx_measured) 
```

I would like to merge #3 before this PR