### PR TITLE
Bump version to 0.3.0 and fix license badge in README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.5...3.30)
 
 project(LieGroupControllers
-  VERSION 0.2.0)
+  VERSION 0.3.0)
 
 # ouptut paths
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
 <a href="https://isocpp.org"><img src="https://img.shields.io/badge/standard-C++17-blue.svg?style=flat&logo=c%2B%2B" alt="C++ Standard"/></a>
-<a href="./LICENSE"><img src="https://img.shields.io/badge/license-LGPL-19c2d8.svg" alt="Size" /></a>
+<a href="./LICENSE"><img src="https://img.shields.io/badge/BSD%20license-3--Clause-green.svg" alt="Size" /></a>
 <a href="https://ami-iit.github.io/lie-group-controllers/doxygen/doc/html/index.html"><img src="https://github.com/ami-iit/lie-group-controllers/workflows/GitHub%20Pages/badge.svg" alt="Size" /></a>
 <a href="https://github.com/ami-iit/lie-group-controllers/actions?query=workflow%3A%22C%2B%2B+CI+Workflow%22"><img src="https://github.com/ami-iit/lie-group-controllers/workflows/C++%20CI%20Workflow/badge.svg" alt="Size" /></a>
 </p>


### PR DESCRIPTION
Important changes like https://github.com/ami-iit/lie-group-controllers/pull/13 and the change of license to BSD-3-Clause were never released. This PR bump the version to 0.3.0 and fix a minor issue in the README, once the PR is merged we can bump do a 0.3.0 tag.