### PR TITLE
Remove version constraint for Eigen3 package for Eigen3 5.0.0 compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ install(FILES ${${LIBRARY_TARGET_NAME}_PRIVATE_PROPORTIONAL_DERIVATIVE_HDR}
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRARY_TARGET_NAME}/impl/ProportionalDerivativeController")
 
 include(InstallBasicPackageFiles)
-set(LIEGROUPCONTROLLERS_PUBLIC_DEPENDENCIES manif "Eigen3 3.2.92")
+set(LIEGROUPCONTROLLERS_PUBLIC_DEPENDENCIES manif Eigen3)
 
 install_basic_package_files(${PROJECT_NAME}
   NAMESPACE LieGroupControllers::

--- a/cmake/LieGroupControllersDependencies.cmake
+++ b/cmake/LieGroupControllersDependencies.cmake
@@ -5,7 +5,7 @@ include(LieGroupControllersFindOptionalDependencies)
 
 #---------------------------------------------
 ## Required Dependencies
-find_package(Eigen3 3.2.92 REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(manif REQUIRED)
 
 #---------------------------------------------


### PR DESCRIPTION
Without this fix, configuration against Eigen 5 fails with:

~~~
CMake Error at cmake/OsqpEigenDependencies.cmake:14 (find_package):
  Could not find a configuration file for package "Eigen3" that is compatible
  with requested version "3.2.92".

  The following configuration files were considered but not accepted:

    /home/runner/work/robotology-superbuild/robotology-superbuild/.pixi/envs/default/share/eigen3/cmake/Eigen3Config.cmake, version: 5.0.0

Call Stack (most recent call first):
~~~

see https://gitlab.com/libeigen/eigen/-/issues/2972 for more details. As Eigen 3.3 was released in 2016, I think we are fine in just asking for Eigen without checking the version of it.

xref: https://github.com/conda-forge/eigen-feedstock/pull/47
xref: https://github.com/robotology/robotology-superbuild/issues/1902
xref: https://github.com/robotology/robotology-superbuild/pull/1903