### PR TITLE
Bump project version from 0.3.0 to 0.3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.5...3.30)
 
 project(LieGroupControllers
-  VERSION 0.3.0)
+  VERSION 0.3.1)
 
 # ouptut paths
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")


### PR DESCRIPTION
To have a release compatibile with Eigen3 5.0.0 .

xref: https://github.com/robotology/robotology-superbuild/issues/1902
xref: https://github.com/robotology/robotology-superbuild/issues/1903
xref: https://github.com/conda-forge/eigen-feedstock/pull/47